### PR TITLE
Restructure and add more tests

### DIFF
--- a/barber/src/main/kotlin/app/cash/barber/BarberException.kt
+++ b/barber/src/main/kotlin/app/cash/barber/BarberException.kt
@@ -16,9 +16,13 @@ class BarberException(
   val problems: List<String>
 ) : IllegalStateException() {
   override fun toString(): String {
+    val sanitizedProblems = problems
+      .map { it.replace("$", "::") }
+      .mapIndexed { index, s -> "${index + 1}) $s\n" }
+      .joinToString("\n")
     return """
       |Problems
-      |${this.problems.mapIndexed { index, s -> "${index + 1}) $s\n" }.joinToString("\n")}
+      |$sanitizedProblems
     """.trimMargin()
   }
 }

--- a/barber/src/main/kotlin/app/cash/barber/BarbershopBuilder.kt
+++ b/barber/src/main/kotlin/app/cash/barber/BarbershopBuilder.kt
@@ -29,7 +29,10 @@ class BarbershopBuilder : Barbershop.Builder {
         |${documentTemplate.locale}.
         |Already Installed
         |DocumentData: $documentDataClass
-        |DocumentTemplate: ${installedDocumentTemplates.row(documentDataClass)}
+        |Locales:
+        |${installedDocumentTemplates.row(documentDataClass).keys.joinToString("\n")}
+        |DocumentTemplates: [
+        |${installedDocumentTemplates.row(documentDataClass).values.joinToString("\n")}]
         |
         |Attempted to Install
         |$documentTemplate
@@ -59,6 +62,38 @@ class BarbershopBuilder : Barbershop.Builder {
    */
   private fun Table<KClass<out DocumentData>, Locale, CompiledDocumentTemplate>.validate() = apply {
     val problems: MutableList<String> = mutableListOf()
+
+    // Barber elements must be installed
+    if (cellSet().isEmpty()) {
+      problems.add("""
+        |No DocumentData or DocumentTemplates installed
+      """.trimMargin())
+    }
+    if (installedDocument.isEmpty()) {
+      problems.add("""
+        |No Documents installed
+      """.trimMargin())
+    }
+
+    if (problems.isNotEmpty()) {
+      throw BarberException(problems)
+    }
+
+    // All installed Documents must be used
+    val usedDocuments = cellSet().map { it.value!!.targets }
+    val b = usedDocuments.reduce { acc, targets ->
+      acc + targets
+    }.toSet()
+    if (!b.containsAll(installedDocument)) {
+      val danglingDocuments = installedDocument.filter { document ->
+        !b.contains(document)
+      }
+      problems.add("""
+      |Document installed that is not used in any installed DocumentTemplates
+      |$danglingDocuments
+      |
+    """.trimMargin())
+    }
 
     cellSet().forEach { cell ->
       val documentDataClass = cell.rowKey!!
@@ -93,38 +128,66 @@ class BarbershopBuilder : Barbershop.Builder {
         codes.forEach { code ->
           if (!documentDataParameterNames.contains(code.rootKey())) {
             problems.add(
-              "Missing variable [$code] in DocumentData [$documentDataClass] for DocumentTemplate field [${documentTemplate.fields[name]?.name}]")
+              "Missing variable [$code] in DocumentData [$documentDataClass] for DocumentTemplate field [${documentTemplate.toDocumentTemplate().fields[name]}]")
           }
         }
       }
 
       // Document targets must have primaryConstructor
       // and installedDocumentTemplates must be able to fulfill Document target parameter requirements
-      documentTemplate.targets.forEach { documentClass ->
+      val allTargetParameters = documentTemplate.targets.map { documentClass ->
         // Validate that Document has a Primary Constructor
         val documentConstructor = documentClass.primaryConstructor
         if (documentConstructor == null) {
           problems.add("No primary constructor for Document class ${documentClass::class}.")
+          listOf()
         } else {
-          // Determine non-nullable required parameters
-          val requiredParameterNames = documentConstructor.parameters.filter {
-            !it.type.isMarkedNullable
-          }.map { it.name }
-
-          // Confirm that required field keys are present in installedDocumentTemplates
-          if (!documentTemplate.fields.keys.containsAll(requiredParameterNames)) {
-            val missingFields = requiredParameterNames.filter {
-              !documentTemplate.fields.containsKey(it)
-            }
-            problems.add("""
-              |Installed DocumentTemplate lacks the required non-null fields for Document target
-              |Missing fields: $missingFields
-              |Document target: ${documentClass::class}
-              |DocumentTemplate: $documentTemplate
-              """.trimMargin())
-          }
+          documentConstructor.parameters
         }
+      }.reduce { acc, params ->
+        acc + params
+      }.toSet()
+      val allTargetFields = allTargetParameters.map {
+        it.name
+      }
+      val requiredTargetFields = allTargetParameters.filter {
+        !it.type.isMarkedNullable
+      }.map { it.name }
 
+      // Confirm that required field keys are present in installedDocumentTemplates
+      if (!documentTemplate.fields.keys.containsAll(requiredTargetFields)) {
+        val missingFields = requiredTargetFields.filter {
+          !documentTemplate.fields.containsKey(it)
+        }
+        val documentsThatRequireMissingField = documentTemplate.targets.map { documentClass ->
+          documentClass to documentClass.primaryConstructor!!.parameters.map { it.name }.filter {
+            missingFields.contains(it)
+          }
+        }.toMap().map { "[${it.key}] requires missing fields ${it.value}" }.joinToString("\n")
+
+
+        problems.add("""
+              |Installed DocumentTemplate missing required fields for Document targets
+              |Missing fields:
+              |$documentsThatRequireMissingField
+              |
+              |DocumentTemplate: ${documentTemplate.toDocumentTemplate()}
+              """.trimMargin())
+      }
+      if (documentTemplate.fields.keys.size > allTargetFields.size) {
+        val additionalFields = documentTemplate.fields.keys.filter { field ->
+          !allTargetFields.contains(field)
+        }
+        problems.add("""
+              |Installed DocumentTemplate has additional fields that are not used in any target Document
+              |Additional fields:
+              |${additionalFields.joinToString("\n")}
+            """.trimMargin())
+      }
+
+
+
+      documentTemplate.targets.forEach { documentClass ->
         // Lookup installed DocumentTemplates that corresponds to DocumentData
         val documentTemplates = row(documentDataClass)
 

--- a/barber/src/main/kotlin/app/cash/barber/RealBarbershop.kt
+++ b/barber/src/main/kotlin/app/cash/barber/RealBarbershop.kt
@@ -18,9 +18,9 @@ internal class RealBarbershop(
       val problems = mutableListOf<String>()
       val documentInstalled = barbers.keys.any { it.document == documentClass }
       val documentDataInstalled = barbers.keys.any { it.documentData == documentDataClass }
-      problems.add("Failed to get Barber<$documentDataClass, $documentClass>")
       if (documentInstalled && documentDataInstalled) {
         problems.add("""
+          |Failed to get Barber<$documentDataClass, $documentClass>
           |Requested Document [$documentClass] is installed
           |Requested DocumentData [$documentDataClass] is installed
           |DocumentTemplate with source=[$documentDataClass] does not have target=[$documentClass]
@@ -28,11 +28,13 @@ internal class RealBarbershop(
       }
       if (!documentInstalled) {
         problems.add("""
+          |Failed to get Barber<$documentDataClass, $documentClass>
           |Document [$documentClass] is not installed in Barbershop
         """.trimMargin())
       }
       if (!documentDataInstalled) {
         problems.add("""
+          |Failed to get Barber<$documentDataClass, $documentClass>
           |DocumentData [$documentDataClass] and corresponding DocumentTemplate(s) are not installed in Barbershop
         """.trimMargin())
       }

--- a/barber/src/main/kotlin/app/cash/barber/RealBarbershop.kt
+++ b/barber/src/main/kotlin/app/cash/barber/RealBarbershop.kt
@@ -12,7 +12,34 @@ internal class RealBarbershop(
   override fun <DD : DocumentData, D : Document> getBarber(
     documentDataClass: KClass<out DD>,
     documentClass: KClass<out D>
-  ): Barber<DD, D> = barbers[BarberKey(documentDataClass, documentClass)] as Barber<DD, D>
+  ): Barber<DD, D> {
+    val barber = barbers[BarberKey(documentDataClass, documentClass)]
+    if (barber == null) {
+      val problems = mutableListOf<String>()
+      val documentInstalled = barbers.keys.any { it.document == documentClass }
+      val documentDataInstalled = barbers.keys.any { it.documentData == documentDataClass }
+      problems.add("Failed to get Barber<$documentDataClass, $documentClass>")
+      if (documentInstalled && documentDataInstalled) {
+        problems.add("""
+          |Requested Document [$documentClass] is installed
+          |Requested DocumentData [$documentDataClass] is installed
+          |DocumentTemplate with source=[$documentDataClass] does not have target=[$documentClass]
+        """.trimMargin())
+      }
+      if (!documentInstalled) {
+        problems.add("""
+          |Document [$documentClass] is not installed in Barbershop
+        """.trimMargin())
+      }
+      if (!documentDataInstalled) {
+        problems.add("""
+          |DocumentData [$documentDataClass] and corresponding DocumentTemplate(s) are not installed in Barbershop
+        """.trimMargin())
+      }
+      throw BarberException(problems)
+    }
+    return barber as Barber<DD, D>
+  }
 
   override fun getAllBarbers(): Map<BarberKey, Barber<DocumentData, Document>> = barbers
 }

--- a/barber/src/main/kotlin/app/cash/barber/Utilities.kt
+++ b/barber/src/main/kotlin/app/cash/barber/Utilities.kt
@@ -26,6 +26,12 @@ internal fun MutableMap<Locale, CompiledDocumentTemplate>.reducedFieldCodeSet() 
 
 internal fun KFunction<*>.asParameterNames() = parameters.associateBy { it.name }
 
+internal fun Mustache?.asString(): String = if (this == null) {
+  ""
+} else {
+  name
+}
+
 /**
  * Nested objects is supported in DocumentData but makes variable validation more of a challenge.
  * Mustache templates referencing nested objects have keys with the flattened hierarchy separated by dots

--- a/barber/src/main/kotlin/app/cash/barber/models/CompiledDocumentTemplate.kt
+++ b/barber/src/main/kotlin/app/cash/barber/models/CompiledDocumentTemplate.kt
@@ -1,5 +1,6 @@
 package app.cash.barber.models
 
+import app.cash.barber.asString
 import com.github.mustachejava.Mustache
 import kotlin.reflect.KClass
 
@@ -18,7 +19,7 @@ data class CompiledDocumentTemplate(
   override fun toString(): String = toDocumentTemplate().toString()
 
   fun toDocumentTemplate() = DocumentTemplate(
-    fields = this.fields.mapValues { it.value?.name ?: "" },
+    fields = this.fields.mapValues { it.value.asString() },
     source = this.source,
     targets = this.targets,
     locale = this.locale

--- a/barber/src/main/kotlin/app/cash/barber/models/CompiledDocumentTemplate.kt
+++ b/barber/src/main/kotlin/app/cash/barber/models/CompiledDocumentTemplate.kt
@@ -14,4 +14,13 @@ data class CompiledDocumentTemplate(
   val source: KClass<out DocumentData>,
   val targets: Set<KClass<out Document>>,
   val locale: Locale
-)
+) {
+  override fun toString(): String = toDocumentTemplate().toString()
+
+  fun toDocumentTemplate() = DocumentTemplate(
+    fields = this.fields.mapValues { it.value?.name ?: "" },
+    source = this.source,
+    targets = this.targets,
+    locale = this.locale
+  )
+}

--- a/barber/src/main/kotlin/app/cash/barber/models/DocumentData.kt
+++ b/barber/src/main/kotlin/app/cash/barber/models/DocumentData.kt
@@ -1,7 +1,5 @@
 package app.cash.barber.models
 
-import kotlin.reflect.KClass
-
 /**
  * This is a schema that specifies the input values for a DocumentTemplate template.
  *

--- a/barber/src/main/kotlin/app/cash/barber/models/DocumentData.kt
+++ b/barber/src/main/kotlin/app/cash/barber/models/DocumentData.kt
@@ -1,5 +1,7 @@
 package app.cash.barber.models
 
+import kotlin.reflect.KClass
+
 /**
  * This is a schema that specifies the input values for a DocumentTemplate template.
  *

--- a/barber/src/main/kotlin/app/cash/barber/models/Locale.kt
+++ b/barber/src/main/kotlin/app/cash/barber/models/Locale.kt
@@ -11,6 +11,7 @@ package app.cash.barber.models
  *  fr-CA: French Canada
  */
 data class Locale(val locale: String) {
+  override fun toString(): String = "[Locale=$locale]"
   companion object {
     val EN_CA = Locale("en-CA")
     val EN_GB = Locale("en-GB")

--- a/barber/src/test/kotlin/app/cash/barber/BarberTest.kt
+++ b/barber/src/test/kotlin/app/cash/barber/BarberTest.kt
@@ -1,7 +1,5 @@
 package app.cash.barber
 
-import app.cash.barber.examples.BadMapleSyrupLocaleResolver
-import app.cash.barber.examples.MapleSyrupOrFirstLocaleResolver
 import app.cash.barber.examples.RecipientReceipt
 import app.cash.barber.examples.TransactionalEmailDocument
 import app.cash.barber.examples.TransactionalSmsDocument
@@ -27,75 +25,75 @@ class BarberTest {
   @Test
   fun `Render an SMS`() {
     val barber = BarbershopBuilder()
-        .installDocument<TransactionalSmsDocument>()
-        .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_US)
-        .build()
+      .installDocument<TransactionalSmsDocument>()
+      .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_US)
+      .build()
 
     val spec = barber.getBarber<RecipientReceipt, TransactionalSmsDocument>()
-        .render(sandy50Receipt, EN_US)
+      .render(sandy50Receipt, EN_US)
 
     assertThat(spec).isEqualTo(
-        TransactionalSmsDocument(
-            sms_body = "Sandy Winchester sent you $50"
-        )
+      TransactionalSmsDocument(
+        sms_body = "Sandy Winchester sent you \$50. It will be available at 2019-05-21T16:02:00Z. Cancel here: https://cash.app/cancel/123"
+      )
     )
   }
 
   @Test
   fun `Rendered spec is of specific Document type and allows field access`() {
     val barber = BarbershopBuilder()
-        .installDocument<TransactionalSmsDocument>()
-        .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_US)
-        .build()
+      .installDocument<TransactionalSmsDocument>()
+      .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_US)
+      .build()
 
     val spec = barber.getBarber<RecipientReceipt, TransactionalSmsDocument>()
-        .render(sandy50Receipt, EN_US)
+      .render(sandy50Receipt, EN_US)
 
     // Spec matches
     assertThat(spec).isEqualTo(
-        TransactionalSmsDocument(
-            sms_body = "Sandy Winchester sent you $50"
-        )
+      TransactionalSmsDocument(
+        sms_body = "Sandy Winchester sent you \$50. It will be available at 2019-05-21T16:02:00Z. Cancel here: https://cash.app/cancel/123"
+      )
     )
 
     // Returned rendered spec is type safely accessible
-    assertThat(spec.sms_body).isEqualTo("Sandy Winchester sent you $50")
+    assertThat(spec.sms_body).isEqualTo("Sandy Winchester sent you \$50. It will be available at 2019-05-21T16:02:00Z. Cancel here: https://cash.app/cancel/123")
   }
 
   @Test
   fun `Render an email`() {
     val recipientReceiptDocumentData = DocumentTemplate(
-        fields = mapOf(
-            "subject" to "{{sender}} sent you {{amount}}",
-            "headline" to "You received {{amount}}",
-            "short_description" to "You’ve received a payment from {{sender}}! The money will be in your bank account " +
-                "{{deposit_expected_at}}.",
-            "primary_button" to "Cancel this payment",
-            "primary_button_url" to "{{cancelUrl}}"
-        ),
-        source = RecipientReceipt::class,
-        targets = setOf(TransactionalEmailDocument::class),
-        locale = EN_US
+      fields = mapOf(
+        "subject" to "{{sender}} sent you {{amount}}",
+        "headline" to "You received {{amount}}",
+        "short_description" to "You’ve received a payment from {{sender}}! The money will be in your bank account " +
+          "{{deposit_expected_at}}.",
+        "primary_button" to "Cancel this payment",
+        "primary_button_url" to "{{cancelUrl}}"
+      ),
+      source = RecipientReceipt::class,
+      targets = setOf(TransactionalEmailDocument::class),
+      locale = EN_US
     )
 
     val barber = BarbershopBuilder()
-        .installDocument<TransactionalEmailDocument>()
-        .installDocumentTemplate<RecipientReceipt>(recipientReceiptDocumentData)
-        .build()
+      .installDocument<TransactionalEmailDocument>()
+      .installDocumentTemplate<RecipientReceipt>(recipientReceiptDocumentData)
+      .build()
 
     val spec = barber.getBarber<RecipientReceipt, TransactionalEmailDocument>()
-        .render(sandy50Receipt, EN_US)
+      .render(sandy50Receipt, EN_US)
 
     assertThat(spec).isEqualTo(
-        TransactionalEmailDocument(
-            subject = "Sandy Winchester sent you $50",
-            headline = "You received $50",
-            short_description = "You’ve received a payment from Sandy Winchester! The money will be in your bank account 2019-05-21T16:02:00Z.",
-            primary_button = "Cancel this payment",
-            primary_button_url = "https://cash.app/cancel/123",
-            secondary_button = null,
-            secondary_button_url = null
-        )
+      TransactionalEmailDocument(
+        subject = "Sandy Winchester sent you $50",
+        headline = "You received $50",
+        short_description = "You’ve received a payment from Sandy Winchester! The money will be in your bank account 2019-05-21T16:02:00Z.",
+        primary_button = "Cancel this payment",
+        primary_button_url = "https://cash.app/cancel/123",
+        secondary_button = null,
+        secondary_button_url = null
+      )
     )
   }
 
@@ -114,395 +112,117 @@ class BarberTest {
     ) : DocumentData
 
     val nestedLoginCode = NestedLoginCode(
-        code = "123-456",
-        button = EmailButton(
-            color = "#B3B3B3",
-            text = "Login",
-            link = "https://cash.app/login",
-            size = "regular"
-        )
+      code = "123-456",
+      button = EmailButton(
+        color = "#B3B3B3",
+        text = "Login",
+        link = "https://cash.app/login",
+        size = "regular"
+      )
     )
 
     val nestedLoginCodeEN_US = DocumentTemplate(
-        fields = mapOf(
-            "subject" to "Your login code is {{code}}",
-            "headline" to "Your login code is {{code}}",
-            "short_description" to "Your login code is {{code}}",
-            "primary_button" to "<Button color=\"{{button.color}}\" size=\"{{button.size}}\">{{button.text}}</Button>",
-            "primary_button_url" to "{{button.link}}",
-            "sms_body" to "Your login code is {{code}}. Go to {{button.link}} to login."
-        ),
-        source = NestedLoginCode::class,
-        targets = setOf(TransactionalEmailDocument::class, TransactionalSmsDocument::class),
-        locale = EN_US
+      fields = mapOf(
+        "subject" to "Your login code is {{code}}",
+        "headline" to "Your login code is {{code}}",
+        "short_description" to "Your login code is {{code}}",
+        "primary_button" to "<Button color=\"{{button.color}}\" size=\"{{button.size}}\">{{button.text}}</Button>",
+        "primary_button_url" to "{{button.link}}",
+        "sms_body" to "Your login code is {{code}}. Go to {{button.link}} to login."
+      ),
+      source = NestedLoginCode::class,
+      targets = setOf(TransactionalEmailDocument::class, TransactionalSmsDocument::class),
+      locale = EN_US
     )
 
     val barber = BarbershopBuilder()
-        .installDocument<TransactionalEmailDocument>()
-        .installDocument<TransactionalSmsDocument>()
-        .installDocumentTemplate<NestedLoginCode>(nestedLoginCodeEN_US)
-        .build()
+      .installDocument<TransactionalEmailDocument>()
+      .installDocument<TransactionalSmsDocument>()
+      .installDocumentTemplate<NestedLoginCode>(nestedLoginCodeEN_US)
+      .build()
 
     val emailSpec = barber.getBarber<NestedLoginCode, TransactionalEmailDocument>()
-        .render(nestedLoginCode, EN_US)
+      .render(nestedLoginCode, EN_US)
 
     assertThat(emailSpec).isEqualTo(
-        TransactionalEmailDocument(
-            subject = "Your login code is 123-456",
-            headline = "Your login code is 123-456",
-            short_description = "Your login code is 123-456",
-            primary_button = "<Button color=\"#B3B3B3\" size=\"regular\">Login</Button>",
-            primary_button_url = "https://cash.app/login",
-            secondary_button = null,
-            secondary_button_url = null
-        )
+      TransactionalEmailDocument(
+        subject = "Your login code is 123-456",
+        headline = "Your login code is 123-456",
+        short_description = "Your login code is 123-456",
+        primary_button = "<Button color=\"#B3B3B3\" size=\"regular\">Login</Button>",
+        primary_button_url = "https://cash.app/login",
+        secondary_button = null,
+        secondary_button_url = null
+      )
     )
 
     val smsSpec = barber.getBarber<NestedLoginCode, TransactionalSmsDocument>()
-        .render(nestedLoginCode, EN_US)
+      .render(nestedLoginCode, EN_US)
 
     assertThat(smsSpec).isEqualTo(
-        TransactionalSmsDocument(
-            sms_body = "Your login code is 123-456. Go to https://cash.app/login to login."
-        )
+      TransactionalSmsDocument(
+        sms_body = "Your login code is 123-456. Go to https://cash.app/login to login."
+      )
     )
   }
 
   @Test
   fun `Can install and render multiple locales`() {
     val barbershop = BarbershopBuilder()
-        .installDocument<TransactionalSmsDocument>()
-        .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_US)
-        .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_CA)
-        .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_GB)
-        .build()
+      .installDocument<TransactionalSmsDocument>()
+      .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_US)
+      .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_CA)
+      .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_GB)
+      .build()
 
     val recipientReceiptSms = barbershop.getBarber<RecipientReceipt, TransactionalSmsDocument>()
 
     val specEN_US = recipientReceiptSms.render(sandy50Receipt, EN_US)
-    assertEquals("Sandy Winchester sent you \$50", specEN_US.sms_body)
+    assertEquals("Sandy Winchester sent you \$50. It will be available at 2019-05-21T16:02:00Z. Cancel here: https://cash.app/cancel/123", specEN_US.sms_body)
     val specEN_CA = recipientReceiptSms.render(sandy50Receipt, EN_CA)
-    assertEquals("Sandy Winchester sent you \$50 Eh?", specEN_CA.sms_body)
+    assertEquals("Sandy Winchester sent you \$50. It will be available at 2019-05-21T16:02:00Z. Cancel here: https://cash.app/cancel/123 Eh?", specEN_CA.sms_body)
     val specEN_GB = recipientReceiptSms.render(sandy50Receipt, EN_GB)
-    assertEquals("Sandy Winchester sent you \$50 The Queen approves.", specEN_GB.sms_body)
+    assertEquals("Sandy Winchester sent you \$50. It will be available at 2019-05-21T16:02:00Z. Cancel here: https://cash.app/cancel/123 The Queen approves.", specEN_GB.sms_body)
   }
 
   @Test
   fun `Render succeeds by fallback for a requested locale that is not installed`() {
     val barber = BarbershopBuilder()
-        .installDocument<TransactionalSmsDocument>()
-        .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_US)
-        .build()
+      .installDocument<TransactionalSmsDocument>()
+      .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_US)
+      .build()
 
     val spec = barber.getBarber<RecipientReceipt, TransactionalSmsDocument>()
-        .render(sandy50Receipt, EN_CA)
+      .render(sandy50Receipt, EN_CA)
 
     assertThat(spec).isEqualTo(
-        TransactionalSmsDocument(
-            sms_body = "Sandy Winchester sent you $50"
-        )
+      TransactionalSmsDocument(
+        sms_body = "Sandy Winchester sent you \$50. It will be available at 2019-05-21T16:02:00Z. Cancel here: https://cash.app/cancel/123"
+      )
     )
-  }
-
-  @Test
-  fun `Use custom LocaleResolver that entirely replaces the default LocaleResolver`() {
-    val customResolver = MapleSyrupOrFirstLocaleResolver()
-    val allLocaleBarbershop = BarbershopBuilder()
-        .installDocument<TransactionalSmsDocument>()
-        .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_US)
-        .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_CA)
-        .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_GB)
-        .setLocaleResolver(customResolver)
-        .build()
-
-    val recipientReceiptSms =
-        allLocaleBarbershop.getBarber<RecipientReceipt, TransactionalSmsDocument>()
-
-    // You always get EN_CA response back with [MapleSyrupOrFirstLocaleResolver]
-    val specEN_US = recipientReceiptSms.render(sandy50Receipt, EN_US)
-    assertEquals("Sandy Winchester sent you \$50 Eh?", specEN_US.sms_body)
-    val specEN_CA = recipientReceiptSms.render(sandy50Receipt, EN_CA)
-    assertEquals("Sandy Winchester sent you \$50 Eh?", specEN_CA.sms_body)
-    val specEN_GB = recipientReceiptSms.render(sandy50Receipt, EN_GB)
-    assertEquals("Sandy Winchester sent you \$50 Eh?", specEN_GB.sms_body)
-
-    // ...and if EN_CA is not installed then [MapleSyrupOrFirstLocaleResolver] returns the first option
-    val onlyUsBarbershop = BarbershopBuilder()
-        .installDocument<TransactionalSmsDocument>()
-        .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_US)
-        .setLocaleResolver(customResolver)
-        .build()
-
-    val specEN_US2 = onlyUsBarbershop.getBarber<RecipientReceipt, TransactionalSmsDocument>()
-        .render(sandy50Receipt, EN_CA)
-    assertEquals("Sandy Winchester sent you \$50", specEN_US2.sms_body)
-  }
-
-  @Test
-  fun `Fails when custom LocaleResolver that doesn't respect contract`() {
-    val customResolver = BadMapleSyrupLocaleResolver()
-    val allLocaleBarbershop = BarbershopBuilder()
-        .installDocument<TransactionalSmsDocument>()
-        .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_US)
-        .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_CA)
-        .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_GB)
-        .setLocaleResolver(customResolver)
-        .build()
-
-    val recipientReceiptSms =
-        allLocaleBarbershop.getBarber<RecipientReceipt, TransactionalSmsDocument>()
-
-    // You always get EN_CA response back with [BadMapleSyrupLocaleResolver]
-    val specEN_US = recipientReceiptSms.render(sandy50Receipt, EN_US)
-    assertEquals("Sandy Winchester sent you \$50 Eh?", specEN_US.sms_body)
-    val specEN_CA = recipientReceiptSms.render(sandy50Receipt, EN_CA)
-    assertEquals("Sandy Winchester sent you \$50 Eh?", specEN_CA.sms_body)
-    val specEN_GB = recipientReceiptSms.render(sandy50Receipt, EN_GB)
-    assertEquals("Sandy Winchester sent you \$50 Eh?", specEN_GB.sms_body)
-
-    // ...and if EN_CA is not installed then [BadMapleSyrupLocaleResolver] blows up
-    val onlyUsBarbershop = BarbershopBuilder()
-        .installDocument<TransactionalSmsDocument>()
-        .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_US)
-        .setLocaleResolver(customResolver)
-        .build()
-
-    val exception = assertFailsWith<BarberException> {
-      onlyUsBarbershop.getBarber<RecipientReceipt, TransactionalSmsDocument>()
-          .render(sandy50Receipt, EN_CA)
-    }
-    assertEquals("""
-      |Problems
-      |1) Resolved entry is not valid key in Map.
-      |LocaleResolver: class app.cash.barber.examples.BadMapleSyrupLocaleResolver
-      |Locale: Locale(locale=en-CA)
-      |Resolved Locale: Locale(locale=en-CA)
-      |
-    """.trimMargin(), exception.toString())
-  }
-
-  @Test
-  fun `Fails when variable in field template is not in source DocumentData`() {
-    data class TradeReceipt(
-      val ticker: String
-    ) : DocumentData
-
-    val tradeReceiptEN_US = DocumentTemplate(
-        fields = mapOf(
-            "sms_body" to "You bought {{ shares }} shares of {{ ticker }}."
-        ),
-        source = TradeReceipt::class,
-        targets = setOf(TransactionalSmsDocument::class),
-        locale = EN_US
-    )
-
-    val exception = assertFailsWith<BarberException> {
-      BarbershopBuilder()
-          .installDocument<TransactionalSmsDocument>()
-          .installDocumentTemplate<TradeReceipt>(tradeReceiptEN_US)
-          .build()
-    }
-    assertThat(exception.problems).containsExactly("Missing variable [shares] in DocumentData " +
-        "[class app.cash.barber.BarberTest\$Fails when variable in field template is not in " +
-        "source DocumentData\$TradeReceipt] for DocumentTemplate field [You bought {{ shares }} shares of {{ ticker }}.]")
-  }
-
-  @Test
-  fun `Fails when variable in data is not used in any field template`() {
-    data class TradeReceipt(
-      val ticker: String,
-      val shares: String
-    ) : DocumentData
-
-    val tradeReceiptEN_US = DocumentTemplate(
-        fields = mapOf(
-            "sms_body" to "Welcome to the {{ ticker }} shareholder family!"
-        ),
-        source = TradeReceipt::class,
-        targets = setOf(TransactionalSmsDocument::class),
-        locale = EN_US
-    )
-
-    val exception = assertFailsWith<BarberException> {
-      BarbershopBuilder()
-          .installDocument<TransactionalSmsDocument>()
-          .installDocumentTemplate<TradeReceipt>(tradeReceiptEN_US)
-          .build()
-    }
-    assertThat(exception.problems).containsExactly("Unused DocumentData variable [shares] in [class app.cash.barber.BarberTest\$Fails when variable in data is not used in any field template\$TradeReceipt] with no usage in installed DocumentTemplate Locales:\n" +
-      "Locale(locale=en-US)")
   }
 
   @Disabled @Test
   fun fieldStemming() {
     val barber = BarbershopBuilder()
-        .installDocument<TransactionalEmailDocument>()
-        .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_US)
-        .build()
+      .installDocument<TransactionalEmailDocument>()
+      .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_US)
+      .build()
 
     val spec = barber.getBarber<RecipientReceipt, TransactionalEmailDocument>()
-        .render(sandy50Receipt, EN_US)
+      .render(sandy50Receipt, EN_US)
 
     assertThat(spec).isEqualTo(
-        TransactionalEmailDocument(
-            subject = "Sandy Winchester sent you $50",
-            headline = "You received $50",
-            short_description = "You’ve received a payment from Sandy Winchester! The money will be in your bank account " +
-                "in 2 days.",
-            primary_button = "Cancel this payment",
-            primary_button_url = "https://cash.app/cancel/123",
-            secondary_button = null,
-            secondary_button_url = null
-        )
+      TransactionalEmailDocument(
+        subject = "Sandy Winchester sent you $50",
+        headline = "You received $50",
+        short_description = "You’ve received a payment from Sandy Winchester! The money will be in your bank account " +
+          "in 2 days.",
+        primary_button = "Cancel this payment",
+        primary_button_url = "https://cash.app/cancel/123",
+        secondary_button = null,
+        secondary_button_url = null
+      )
     )
-  }
-
-  @Disabled @Test
-  fun copyUsesFieldThatDoesntExist() {
-    val recipientReceiptDocumentData = DocumentTemplate(
-        fields = mapOf(
-            "subject" to "{{sender}} sent you {{totally_invalid_field}}",
-            "headline" to "",
-            "short_description" to "",
-            "primary_button" to "",
-            "primary_button_url" to ""
-        ),
-        source = RecipientReceipt::class,
-        targets = setOf(TransactionalEmailDocument::class),
-        locale = EN_US
-    )
-
-    val exception = assertFailsWith<BarberException> {
-      BarbershopBuilder()
-          .installDocumentTemplate<RecipientReceipt>(recipientReceiptDocumentData)
-    }
-    assertThat(exception.problems).containsExactly("""
-        |output field 'subject' uses 'totally_invalid_field' but 'RecipientReceipt' has no such field
-        |  {{sender}} sent you {{totally_invalid_field}}
-        |  valid fields are [sender, amount, cancelUrl, deposit_expected_at]
-        |""".trimMargin()
-    )
-  }
-
-  // TODO: name the input fields ('sender', 'amount' etc.) that the DocumentData defines
-  // TODO: name the output fields ('subject', 'headline' etc.) that the DocuemntSpec has
-
-  @Disabled @Test
-  fun copyDoesntOutputFieldThatIsRequired() {
-    val recipientReceiptDocumentData = DocumentTemplate(
-        fields = mapOf(
-            "subject" to "",
-            "headline" to "",
-            "primary_button" to "",
-            "primary_button_url" to ""
-        ),
-        source = RecipientReceipt::class,
-        targets = setOf(TransactionalEmailDocument::class),
-        locale = EN_US
-    )
-
-    val exception = assertFailsWith<BarberException> {
-      BarbershopBuilder()
-          .installDocumentTemplate<RecipientReceipt>(recipientReceiptDocumentData)
-    }
-    assertThat(exception.problems).containsExactly("""
-        |output field 'short_description' is required but was not found
-        |""".trimMargin()
-    )
-  }
-
-  @Disabled @Test
-  fun copyOutputsFieldThatIsUnknown() {
-    val recipientReceiptDocumentData = DocumentTemplate(
-        fields = mapOf(
-            "subject" to "",
-            "headline" to "",
-            "primary_button" to "",
-            "primary_button_url" to "",
-            "tertiary_button_url" to ""
-        ),
-        source = RecipientReceipt::class,
-        targets = setOf(TransactionalEmailDocument::class),
-        locale = EN_US
-    )
-
-    val exception = assertFailsWith<BarberException> {
-      BarbershopBuilder()
-          .installDocumentTemplate<RecipientReceipt>(recipientReceiptDocumentData)
-    }
-    assertThat(exception.problems).containsExactly("""
-        |output field 'tertiary_button_url' is not used
-        |""".trimMargin()
-    )
-  }
-
-  @Disabled @Test
-  fun renderUnknownDocumentData() {
-    val recipientReceiptDocumentData = DocumentTemplate(
-        fields = mapOf(
-            "subject" to "",
-            "headline" to "",
-            "short_description" to "",
-            "primary_button" to "",
-            "primary_button_url" to ""
-        ),
-        source = RecipientReceipt::class,
-        targets = setOf(TransactionalEmailDocument::class),
-        locale = EN_US
-    )
-
-    BarbershopBuilder()
-        .installDocumentTemplate<RecipientReceipt>(recipientReceiptDocumentData)
-
-    val exception = assertFailsWith<BarberException> {
-      // TODO confirm failure when render (SenderReceipt::class, TransactionalEmailDocument::class)
-    }
-
-    assertThat(exception.problems).containsExactly("""
-        |unknown copy model: SenderReceipt
-        |""".trimMargin()
-    )
-  }
-
-  @Disabled @Test
-  fun renderUnknownDocument() {
-    val recipientReceiptDocumentData = DocumentTemplate(
-        fields = mapOf(
-            "subject" to "",
-            "headline" to "",
-            "short_description" to "",
-            "primary_button" to "",
-            "primary_button_url" to ""
-        ),
-        source = RecipientReceipt::class,
-        targets = setOf(TransactionalEmailDocument::class),
-        locale = EN_US
-    )
-
-    BarbershopBuilder()
-        .installDocumentTemplate<RecipientReceipt>(recipientReceiptDocumentData)
-
-    val exception = assertFailsWith<BarberException> {
-      // TODO confirm failure when render (RecipientReceipt::class, SmsDocument::class)
-    }
-
-    assertThat(exception.problems).containsExactly("""
-        |unknown document: SmsDocument
-        |""".trimMargin()
-    )
-  }
-
-  @Disabled @Test
-  fun singleDocumentDataHasMultipleTargets() {
-    TODO()
-  }
-
-  @Disabled @Test
-  fun failOnSingleUnit() {
-    data class StrangeUnitDocumentData(
-      val strange: Unit
-    ) : DocumentData
-
-    TODO()
   }
 }

--- a/barber/src/test/kotlin/app/cash/barber/BarberTest.kt
+++ b/barber/src/test/kotlin/app/cash/barber/BarberTest.kt
@@ -16,7 +16,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
 
 /**
  * These our integration end to end tests

--- a/barber/src/test/kotlin/app/cash/barber/BarbershopBuilderTest.kt
+++ b/barber/src/test/kotlin/app/cash/barber/BarbershopBuilderTest.kt
@@ -7,6 +7,12 @@ import app.cash.barber.examples.TransactionalSmsDocument
 import app.cash.barber.examples.recipientReceiptSmsDocumentTemplateEN_CA
 import app.cash.barber.examples.recipientReceiptSmsDocumentTemplateEN_GB
 import app.cash.barber.examples.recipientReceiptSmsDocumentTemplateEN_US
+import app.cash.barber.examples.senderReceiptEmailDocumentTemplateEN_US
+import app.cash.barber.models.DocumentData
+import app.cash.barber.models.DocumentTemplate
+import app.cash.barber.models.Locale
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -39,10 +45,46 @@ class BarbershopBuilderTest {
   }
 
   @Test
-  fun `Fails when DocumentTemplate targets are not installed Documents`() {
+  fun `Install fails on no DocumentTemplate and DocumentData`() {
+    val exception = assertFailsWith<BarberException> {
+      BarbershopBuilder()
+        .installDocument<TransactionalEmailDocument>()
+        .build()
+    }
+    assertEquals(
+      """
+        |Problems
+        |1) No DocumentData or DocumentTemplates installed
+        |
+      """.trimMargin(),
+      exception.toString())
+
+  }
+
+  @Test
+  fun `Install fails on no Documents`() {
     val exception = assertFailsWith<BarberException> {
       BarbershopBuilder()
         .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_US)
+        .build()
+    }
+    assertEquals(
+      """
+        |Problems
+        |1) No Documents installed
+        |
+      """.trimMargin(),
+      exception.toString())
+
+  }
+
+  @Test
+  fun `Fails when DocumentTemplate target Documents are not installed`() {
+    val exception = assertFailsWith<BarberException> {
+      BarbershopBuilder()
+        .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_US)
+        .installDocumentTemplate<SenderReceipt>(senderReceiptEmailDocumentTemplateEN_US)
+        .installDocument<TransactionalEmailDocument>()
         .build()
     }
     assertEquals("""
@@ -57,11 +99,10 @@ class BarbershopBuilderTest {
 
   @Test
   fun `Fails when DocumentTemplate installed with non-source DocumentData`() {
-    val builder = BarbershopBuilder()
-      .installDocument<TransactionalEmailDocument>()
     val exception = assertFailsWith<BarberException> {
-      builder
+      BarbershopBuilder()
         .installDocumentTemplate<SenderReceipt>(recipientReceiptSmsDocumentTemplateEN_US)
+        .installDocument<TransactionalSmsDocument>()
         .build()
     }
     assertEquals("""
@@ -70,19 +111,247 @@ class BarbershopBuilderTest {
       |DocumentTemplate.source: class app.cash.barber.examples.RecipientReceipt
       |DocumentData: class app.cash.barber.examples.SenderReceipt
       |
-      |2) Attempted to install DocumentTemplate without the corresponding Document being installed.
-      |Not installed DocumentTemplate.targets:
-      |[class app.cash.barber.examples.TransactionalSmsDocument]
+      |2) Missing variable [sender] in DocumentData [class app.cash.barber.examples.SenderReceipt] for DocumentTemplate field [{{sender}} sent you {{amount}}. It will be available at {{ deposit_expected_at }}. Cancel here: {{ cancelUrl }}]
       |
-      |3) Missing variable [sender] in DocumentData [class app.cash.barber.examples.SenderReceipt] for DocumentTemplate field [{{sender}} sent you {{amount}}]
-      |
-      |4) Missing variable [sender] in DocumentData [class app.cash.barber.examples.SenderReceipt] for DocumentTemplate field [You’ve received a payment from {{sender}}! The money will be in your bank account {{deposit_expected_at.casual}}.]
-      |
-      |5) Missing variable [sender] in DocumentData [class app.cash.barber.examples.SenderReceipt] for DocumentTemplate field [{{sender}} sent you {{amount}}]
-      |
-      |6) Unused DocumentData variable [recipient] in [class app.cash.barber.examples.SenderReceipt] with no usage in installed DocumentTemplate Locales:
-      |Locale(locale=en-US)
+      |3) Unused DocumentData variable [recipient] in [class app.cash.barber.examples.SenderReceipt] with no usage in installed DocumentTemplate Locales:
+      |[Locale=en-US]
       |
       """.trimMargin(), exception.toString())
+  }
+
+  @Test
+  fun `Fails on unused dangling installed Document`() {
+    val exception = assertFailsWith<BarberException> {
+      BarbershopBuilder()
+        .installDocument<TransactionalEmailDocument>()
+        .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_US)
+        .installDocument<TransactionalSmsDocument>()
+        .build()
+    }
+    assertEquals("""
+      |Problems
+      |1) Document installed that is not used in any installed DocumentTemplates
+      |[class app.cash.barber.examples.TransactionalEmailDocument]
+      |
+      |
+      """.trimMargin(), exception.toString())
+  }
+
+  @Test
+  fun `Fails when variable in field template is not in source DocumentData`() {
+    data class TradeReceipt(
+      val ticker: String
+    ) : DocumentData
+
+    val tradeReceiptEN_US = DocumentTemplate(
+      fields = mapOf(
+        "sms_body" to "You bought {{ shares }} shares of {{ ticker }}."
+      ),
+      source = TradeReceipt::class,
+      targets = setOf(TransactionalSmsDocument::class),
+      locale = Locale.EN_US
+    )
+
+    val exception = assertFailsWith<BarberException> {
+      BarbershopBuilder()
+        .installDocument<TransactionalSmsDocument>()
+        .installDocumentTemplate<TradeReceipt>(tradeReceiptEN_US)
+        .build()
+    }
+    assertEquals(
+      """
+        |Problems
+        |1) Missing variable [shares] in DocumentData [class app.cash.barber.BarbershopBuilderTest::Fails when variable in field template is not in source DocumentData::TradeReceipt] for DocumentTemplate field [You bought {{ shares }} shares of {{ ticker }}.]
+        |
+      """.trimMargin(),
+      exception.toString())
+  }
+
+  @Test
+  fun `Fails when variable in data is not used in any field template`() {
+    data class TradeReceipt(
+      val ticker: String,
+      val shares: String
+    ) : DocumentData
+
+    val tradeReceiptEN_US = DocumentTemplate(
+      fields = mapOf(
+        "sms_body" to "Welcome to the {{ ticker }} shareholder family!"
+      ),
+      source = TradeReceipt::class,
+      targets = setOf(TransactionalSmsDocument::class),
+      locale = Locale.EN_US
+    )
+
+    val exception = assertFailsWith<BarberException> {
+      BarbershopBuilder()
+        .installDocument<TransactionalSmsDocument>()
+        .installDocumentTemplate<TradeReceipt>(tradeReceiptEN_US)
+        .build()
+    }
+    assertEquals(
+      """
+        |Problems
+        |1) Unused DocumentData variable [shares] in [class app.cash.barber.BarbershopBuilderTest::Fails when variable in data is not used in any field template::TradeReceipt] with no usage in installed DocumentTemplate Locales:
+        |[Locale=en-US]
+        |
+      """.trimMargin(),
+      exception.toString())
+  }
+
+  @Test
+  fun `Fails when DocumentTemplate does not have sufficient fields for target Document`() {
+    val recipientReceiptDocumentData = DocumentTemplate(
+      fields = mapOf(
+        "subject" to "{{ sender }} sent {{ amount }} on {{ deposit_expected_at }}. Cancel here: {{ cancelUrl }}"
+      ),
+      source = RecipientReceipt::class,
+      targets = setOf(TransactionalSmsDocument::class),
+      locale = Locale.EN_US
+    )
+
+    val exception = assertFailsWith<BarberException> {
+      BarbershopBuilder()
+        .installDocumentTemplate<RecipientReceipt>(recipientReceiptDocumentData)
+        .installDocument<TransactionalSmsDocument>()
+        .build()
+    }
+    assertEquals(
+      """
+        |Problems
+        |1) Installed DocumentTemplate missing required fields for Document targets
+        |Missing fields:
+        |[class app.cash.barber.examples.TransactionalSmsDocument] requires missing fields [sms_body]
+        |
+        |DocumentTemplate: DocumentTemplate(
+        | fields = mapOf(
+        |   subject={{ sender }} sent {{ amount }} on {{ deposit_expected_at }}. Cancel here: {{ cancelUrl }}
+        | ),
+        | source = class app.cash.barber.examples.RecipientReceipt,
+        | targets = [class app.cash.barber.examples.TransactionalSmsDocument],
+        | locale = [Locale=en-US]
+        |)
+        |
+      """.trimMargin(),
+      exception.toString())
+  }
+
+  @Test
+  fun `DocumentTemplate has extra fields unused by target Documents`() {
+    val recipientReceiptDocumentData = DocumentTemplate(
+      fields = mapOf(
+        "sms_body" to "{{ sender }} sent you {{ amount }} on {{ deposit_expected_at }}. Cancel here: {{ cancelUrl }}",
+        "extra_field" to "This field is unused in any target document"
+      ),
+    source = RecipientReceipt::class,
+    targets = setOf(TransactionalSmsDocument::class),
+    locale = Locale.EN_US
+    )
+
+    val exception = assertFailsWith<BarberException> {
+      BarbershopBuilder()
+        .installDocumentTemplate<RecipientReceipt>(recipientReceiptDocumentData)
+        .installDocument<TransactionalSmsDocument>()
+        .build()
+    }
+    assertEquals(
+      """
+        |Problems
+        |1) Installed DocumentTemplate has additional fields that are not used in any target Document
+        |Additional fields:
+        |extra_field
+        |
+      """.trimMargin(),
+      exception.toString())
+  }
+
+  @Test
+  fun `Fails on duplicate install of DocumentTemplate`() {
+    val first = DocumentTemplate(
+      fields = mapOf(
+        "sms_body" to "first {{ sender }} sent you {{ amount }} on {{ deposit_expected_at }}. Cancel here: {{ cancelUrl }}"
+      ),
+      source = RecipientReceipt::class,
+      targets = setOf(TransactionalSmsDocument::class),
+      locale = Locale.EN_US
+    )
+    val second = DocumentTemplate(
+      fields = mapOf(
+        "sms_body" to "second {{ sender }} sent you {{ amount }} on {{ deposit_expected_at }}. Cancel here: {{ cancelUrl }}"
+      ),
+      source = RecipientReceipt::class,
+      targets = setOf(TransactionalSmsDocument::class),
+      locale = Locale.EN_US
+    )
+
+    val exception = assertFailsWith<BarberException> {
+      BarbershopBuilder()
+        .installDocumentTemplate<RecipientReceipt>(first)
+        .installDocumentTemplate<RecipientReceipt>(second)
+        .installDocument<TransactionalSmsDocument>()
+        .build()
+    }
+    assertEquals(
+      """
+        |Problems
+        |1) Attempted to install DocumentTemplate that will overwrite an already installed DocumentTemplate with locale
+        |[Locale=en-US].
+        |Already Installed
+        |DocumentData: class app.cash.barber.examples.RecipientReceipt
+        |Locales:
+        |[Locale=en-US]
+        |DocumentTemplates: [
+        |DocumentTemplate(
+        | fields = mapOf(
+        |   sms_body=first {{ sender }} sent you {{ amount }} on {{ deposit_expected_at }}. Cancel here: {{ cancelUrl }}
+        | ),
+        | source = class app.cash.barber.examples.RecipientReceipt,
+        | targets = [class app.cash.barber.examples.TransactionalSmsDocument],
+        | locale = [Locale=en-US]
+        |)]
+        |
+        |Attempted to Install
+        |DocumentTemplate(
+        | fields = mapOf(
+        |   sms_body=second {{ sender }} sent you {{ amount }} on {{ deposit_expected_at }}. Cancel here: {{ cancelUrl }}
+        | ),
+        | source = class app.cash.barber.examples.RecipientReceipt,
+        | targets = [class app.cash.barber.examples.TransactionalSmsDocument],
+        | locale = [Locale=en-US]
+        |)
+        |
+      """.trimMargin(),
+      exception.toString())
+  }
+
+  @Disabled @Test
+  fun `Fails on a non supported DocumentData unit`() {
+    data class StrangeUnitDocumentData(
+      val strange: Unit
+    ) : DocumentData
+
+    val strangeUnitEN_US = DocumentTemplate(
+      fields = mapOf(
+        "sms_body" to "That's {{ strange }}"
+      ),
+      source = StrangeUnitDocumentData::class,
+      targets = setOf(TransactionalSmsDocument::class),
+      locale = Locale.EN_US
+    )
+
+    val exception = assertFailsWith<BarberException> {
+      BarbershopBuilder()
+        .installDocument<TransactionalEmailDocument>()
+        .installDocument<TransactionalSmsDocument>()
+        .installDocumentTemplate<StrangeUnitDocumentData>(strangeUnitEN_US)
+        .build()
+    }
+    assertEquals(
+      """
+        |Problems
+        |1) ...
+        |
+      """.trimMargin(),
+      exception.toString())
   }
 }

--- a/barber/src/test/kotlin/app/cash/barber/BarbershopBuilderTest.kt
+++ b/barber/src/test/kotlin/app/cash/barber/BarbershopBuilderTest.kt
@@ -11,8 +11,6 @@ import app.cash.barber.examples.senderReceiptEmailDocumentTemplateEN_US
 import app.cash.barber.models.DocumentData
 import app.cash.barber.models.DocumentTemplate
 import app.cash.barber.models.Locale
-import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -58,7 +56,6 @@ class BarbershopBuilderTest {
         |
       """.trimMargin(),
       exception.toString())
-
   }
 
   @Test
@@ -75,7 +72,6 @@ class BarbershopBuilderTest {
         |
       """.trimMargin(),
       exception.toString())
-
   }
 
   @Test
@@ -319,37 +315,6 @@ class BarbershopBuilderTest {
         | targets = [class app.cash.barber.examples.TransactionalSmsDocument],
         | locale = [Locale=en-US]
         |)
-        |
-      """.trimMargin(),
-      exception.toString())
-  }
-
-  @Disabled @Test
-  fun `Fails on a non supported DocumentData unit`() {
-    data class StrangeUnitDocumentData(
-      val strange: Unit
-    ) : DocumentData
-
-    val strangeUnitEN_US = DocumentTemplate(
-      fields = mapOf(
-        "sms_body" to "That's {{ strange }}"
-      ),
-      source = StrangeUnitDocumentData::class,
-      targets = setOf(TransactionalSmsDocument::class),
-      locale = Locale.EN_US
-    )
-
-    val exception = assertFailsWith<BarberException> {
-      BarbershopBuilder()
-        .installDocument<TransactionalEmailDocument>()
-        .installDocument<TransactionalSmsDocument>()
-        .installDocumentTemplate<StrangeUnitDocumentData>(strangeUnitEN_US)
-        .build()
-    }
-    assertEquals(
-      """
-        |Problems
-        |1) ...
         |
       """.trimMargin(),
       exception.toString())

--- a/barber/src/test/kotlin/app/cash/barber/BarbershopTest.kt
+++ b/barber/src/test/kotlin/app/cash/barber/BarbershopTest.kt
@@ -55,8 +55,7 @@ class BarbershopTest {
       """
         |Problems
         |1) Failed to get Barber<class app.cash.barber.examples.RecipientReceipt, class app.cash.barber.examples.TransactionalEmailDocument>
-        |
-        |2) Requested Document [class app.cash.barber.examples.TransactionalEmailDocument] is installed
+        |Requested Document [class app.cash.barber.examples.TransactionalEmailDocument] is installed
         |Requested DocumentData [class app.cash.barber.examples.RecipientReceipt] is installed
         |DocumentTemplate with source=[class app.cash.barber.examples.RecipientReceipt] does not have target=[class app.cash.barber.examples.TransactionalEmailDocument]
         |
@@ -78,8 +77,7 @@ class BarbershopTest {
       """
         |Problems
         |1) Failed to get Barber<class app.cash.barber.examples.RecipientReceipt, class app.cash.barber.examples.TransactionalEmailDocument>
-        |
-        |2) Document [class app.cash.barber.examples.TransactionalEmailDocument] is not installed in Barbershop
+        |Document [class app.cash.barber.examples.TransactionalEmailDocument] is not installed in Barbershop
         |
       """.trimMargin(),
       exception.toString())

--- a/barber/src/test/kotlin/app/cash/barber/BarbershopTest.kt
+++ b/barber/src/test/kotlin/app/cash/barber/BarbershopTest.kt
@@ -1,29 +1,32 @@
 package app.cash.barber
 
 import app.cash.barber.examples.RecipientReceipt
+import app.cash.barber.examples.SenderReceipt
+import app.cash.barber.examples.TransactionalEmailDocument
 import app.cash.barber.examples.TransactionalSmsDocument
 import app.cash.barber.examples.recipientReceiptSmsDocumentTemplateEN_CA
 import app.cash.barber.examples.recipientReceiptSmsDocumentTemplateEN_GB
 import app.cash.barber.examples.recipientReceiptSmsDocumentTemplateEN_US
+import app.cash.barber.examples.senderReceiptEmailDocumentTemplateEN_US
 import app.cash.barber.models.BarberKey
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 
 class BarbershopTest {
   @Test
-  fun `getBarber`() {
+  fun `getBarber happy path`() {
     val barbershop = BarbershopBuilder()
       .installDocument<TransactionalSmsDocument>()
       .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_US)
       .build()
     val barber = barbershop.getBarber<RecipientReceipt, TransactionalSmsDocument>()
     assertEquals("class app.cash.barber.RealBarber", barber::class.toString())
-    // TODO confirm that the returned Barber is strictly of the requested DocumentData and Document types
   }
 
   @Test
-  fun `getAllBarbers`() {
+  fun `getAllBarbers happy path`() {
     val barbershop = BarbershopBuilder()
       .installDocument<TransactionalSmsDocument>()
       .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_US)
@@ -34,5 +37,51 @@ class BarbershopTest {
     assertEquals(1, barbers.size)
     assertThat(barbers.keys).contains(
       BarberKey(RecipientReceipt::class, TransactionalSmsDocument::class))
+  }
+
+  @Test
+  fun `getBarber fail on non-target Document, with Document installed`() {
+    val barber = BarbershopBuilder()
+      .installDocumentTemplate<SenderReceipt>(senderReceiptEmailDocumentTemplateEN_US)
+      .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_US)
+      .installDocument<TransactionalSmsDocument>()
+      .installDocument<TransactionalEmailDocument>()
+      .build()
+
+    val exception = assertFailsWith<BarberException> {
+      barber.getBarber<RecipientReceipt, TransactionalEmailDocument>()
+    }
+    assertEquals(
+      """
+        |Problems
+        |1) Failed to get Barber<class app.cash.barber.examples.RecipientReceipt, class app.cash.barber.examples.TransactionalEmailDocument>
+        |
+        |2) Requested Document [class app.cash.barber.examples.TransactionalEmailDocument] is installed
+        |Requested DocumentData [class app.cash.barber.examples.RecipientReceipt] is installed
+        |DocumentTemplate with source=[class app.cash.barber.examples.RecipientReceipt] does not have target=[class app.cash.barber.examples.TransactionalEmailDocument]
+        |
+      """.trimMargin(),
+      exception.toString())
+  }
+
+  @Test
+  fun `getBarber fail on non-target Document, with Document not installed`() {
+    val barber = BarbershopBuilder()
+      .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_US)
+      .installDocument<TransactionalSmsDocument>()
+      .build()
+
+    val exception = assertFailsWith<BarberException> {
+      barber.getBarber<RecipientReceipt, TransactionalEmailDocument>()
+    }
+    assertEquals(
+      """
+        |Problems
+        |1) Failed to get Barber<class app.cash.barber.examples.RecipientReceipt, class app.cash.barber.examples.TransactionalEmailDocument>
+        |
+        |2) Document [class app.cash.barber.examples.TransactionalEmailDocument] is not installed in Barbershop
+        |
+      """.trimMargin(),
+      exception.toString())
   }
 }

--- a/barber/src/test/kotlin/app/cash/barber/LocaleResolverTest.kt
+++ b/barber/src/test/kotlin/app/cash/barber/LocaleResolverTest.kt
@@ -1,0 +1,97 @@
+package app.cash.barber
+
+import app.cash.barber.examples.BadMapleSyrupLocaleResolver
+import app.cash.barber.examples.MapleSyrupOrFirstLocaleResolver
+import app.cash.barber.examples.RecipientReceipt
+import app.cash.barber.examples.TransactionalSmsDocument
+import app.cash.barber.examples.recipientReceiptSmsDocumentTemplateEN_CA
+import app.cash.barber.examples.recipientReceiptSmsDocumentTemplateEN_GB
+import app.cash.barber.examples.recipientReceiptSmsDocumentTemplateEN_US
+import app.cash.barber.examples.sandy50Receipt
+import app.cash.barber.models.Locale
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class LocaleResolverTest {
+  @Test
+  fun `Use custom LocaleResolver that entirely replaces the default LocaleResolver`() {
+    val customResolver = MapleSyrupOrFirstLocaleResolver()
+    val allLocaleBarbershop = BarbershopBuilder()
+      .installDocument<TransactionalSmsDocument>()
+      .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_US)
+      .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_CA)
+      .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_GB)
+      .setLocaleResolver(customResolver)
+      .build()
+
+    val recipientReceiptSms =
+      allLocaleBarbershop.getBarber<RecipientReceipt, TransactionalSmsDocument>()
+
+    // You always get EN_CA response back with [MapleSyrupOrFirstLocaleResolver]
+    val expectedEN_CA = "Sandy Winchester sent you $50. It will be available at 2019-05-21T16:02:00Z. Cancel here: https://cash.app/cancel/123 Eh?"
+    val specEN_US = recipientReceiptSms.render(sandy50Receipt, Locale.EN_US)
+    assertEquals(expectedEN_CA, specEN_US.sms_body)
+    val specEN_CA = recipientReceiptSms.render(sandy50Receipt, Locale.EN_CA)
+    assertEquals(expectedEN_CA, specEN_CA.sms_body)
+    val specEN_GB = recipientReceiptSms.render(sandy50Receipt, Locale.EN_GB)
+    assertEquals(expectedEN_CA, specEN_GB.sms_body)
+
+    // ...and if EN_CA is not installed then [MapleSyrupOrFirstLocaleResolver] returns the first option
+    val onlyUsBarbershop = BarbershopBuilder()
+      .installDocument<TransactionalSmsDocument>()
+      .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_US)
+      .setLocaleResolver(customResolver)
+      .build()
+
+    val specEN_US2 = onlyUsBarbershop.getBarber<RecipientReceipt, TransactionalSmsDocument>()
+      .render(sandy50Receipt, Locale.EN_CA)
+    assertEquals("Sandy Winchester sent you \$50. It will be available at 2019-05-21T16:02:00Z. Cancel here: https://cash.app/cancel/123", specEN_US2.sms_body)
+  }
+
+  @Test
+  fun `Fails when custom LocaleResolver that doesn't respect contract`() {
+    val customResolver = BadMapleSyrupLocaleResolver()
+    val allLocaleBarbershop = BarbershopBuilder()
+      .installDocument<TransactionalSmsDocument>()
+      .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_US)
+      .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_CA)
+      .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_GB)
+      .setLocaleResolver(customResolver)
+      .build()
+
+    val recipientReceiptSms =
+      allLocaleBarbershop.getBarber<RecipientReceipt, TransactionalSmsDocument>()
+
+    // You always get EN_CA response back with [BadMapleSyrupLocaleResolver]
+    val expectedEN_CA = "Sandy Winchester sent you $50. It will be available at 2019-05-21T16:02:00Z. Cancel here: https://cash.app/cancel/123 Eh?"
+    val specEN_US = recipientReceiptSms.render(sandy50Receipt, Locale.EN_US)
+    assertEquals(expectedEN_CA, specEN_US.sms_body)
+    val specEN_CA = recipientReceiptSms.render(sandy50Receipt, Locale.EN_CA)
+    assertEquals(expectedEN_CA, specEN_CA.sms_body)
+    val specEN_GB = recipientReceiptSms.render(sandy50Receipt, Locale.EN_GB)
+    assertEquals(expectedEN_CA, specEN_GB.sms_body)
+
+    // ...and if EN_CA is not installed then [BadMapleSyrupLocaleResolver] blows up
+    val onlyUsBarbershop = BarbershopBuilder()
+      .installDocument<TransactionalSmsDocument>()
+      .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_US)
+      .setLocaleResolver(customResolver)
+      .build()
+
+    val exception = assertFailsWith<BarberException> {
+      onlyUsBarbershop.getBarber<RecipientReceipt, TransactionalSmsDocument>()
+        .render(sandy50Receipt, Locale.EN_CA)
+    }
+    assertEquals(
+      """
+        |Problems
+        |1) Resolved entry is not valid key in Map.
+        |LocaleResolver: class app.cash.barber.examples.BadMapleSyrupLocaleResolver
+        |Locale: [Locale=en-CA]
+        |Resolved Locale: [Locale=en-CA]
+        |
+      """.trimMargin(),
+      exception.toString())
+  }
+}

--- a/barber/src/test/kotlin/app/cash/barber/examples/TestFixtures.kt
+++ b/barber/src/test/kotlin/app/cash/barber/examples/TestFixtures.kt
@@ -7,6 +7,15 @@ import app.cash.barber.models.Locale.Companion.EN_US
 
 val recipientReceiptSmsDocumentTemplateEN_US = DocumentTemplate(
   fields = mapOf(
+    "sms_body" to "{{sender}} sent you {{amount}}. It will be available at {{ deposit_expected_at }}. Cancel here: {{ cancelUrl }}"
+  ),
+  source = RecipientReceipt::class,
+  targets = setOf(TransactionalSmsDocument::class),
+  locale = EN_US
+)
+
+val recipientReceiptSmsEmailDocumentTemplateEN_US = DocumentTemplate(
+  fields = mapOf(
     "subject" to "{{sender}} sent you {{amount}}",
     "headline" to "You received {{amount}}",
     "short_description" to "You’ve received a payment from {{sender}}! The money will be in your bank account " +
@@ -16,7 +25,21 @@ val recipientReceiptSmsDocumentTemplateEN_US = DocumentTemplate(
     "sms_body" to "{{sender}} sent you {{amount}}"
   ),
   source = RecipientReceipt::class,
-  targets = setOf(TransactionalSmsDocument::class),
+  targets = setOf(TransactionalEmailDocument::class, TransactionalSmsDocument::class),
+  locale = EN_US
+)
+
+val senderReceiptEmailDocumentTemplateEN_US = DocumentTemplate(
+  fields = mapOf(
+    "subject" to "You sent {{amount}} to {{recipient}}",
+    "headline" to "You sent {{amount}}",
+    "short_description" to "You sent a payment to {{recipient}}! The money will be in their bank account " +
+      "{{deposit_expected_at.casual}}.",
+    "primary_button" to "Cancel this payment",
+    "primary_button_url" to "{{cancelUrl}}"
+  ),
+  source = SenderReceipt::class,
+  targets = setOf(TransactionalEmailDocument::class),
   locale = EN_US
 )
 


### PR DESCRIPTION
* Add broader test coverage of validation logic
* Add validation and tests for most of the disabled tests (initially written early in library develoment but functionality not yet built)
* Move validation related tests to `BarbershopBuilderTest`
* Move local resolver tests to `LocaleResolverTest`
* Add `toString` override to many Barber elements for more readable error logs