### PR TITLE
Treat warnings as warnings.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,13 +58,11 @@ subprojects {
   compileKotlin {
     kotlinOptions {
       jvmTarget = "1.8"
-      allWarningsAsErrors = true
     }
   }
   compileTestKotlin {
     kotlinOptions {
       jvmTarget = "1.8"
-      allWarningsAsErrors = true
     }
   }
   sourceSets {


### PR DESCRIPTION
Kotlin lacks a mechanism to treat deprecation warnings as
warnings and everything else as errors. Vote for this here:
https://youtrack.jetbrains.com/issue/KT-24746