### PR TITLE
[CLOSES #39] Add BarberField

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,37 @@ val sandy50Receipt = RecipientReceipt(
 val renderedSms = recipientReceiptSms.render(sandy50Receipt, EN_US)
 ```
 
+## @BarberField, BarberFieldEncoding, and HTML Character Escaping
+
+The `@BarberField` annotation can be used on Document class `val` fields to declare that the field should be rendered and treated according to a specific `BarberFieldEncoding`.
+
+`BarberFieldEncoding` can be for now `STRING_HTML` or `STRING_PLAINTEXT`. 
+
+By default, all fields are treated as `STRING_HTML` and have common HTML escaping of characters for safety. 
+
+When a field is annotated as `STRING_PLAINTEXT`, characters will not be escaped.
+
+```kotlin
+data class EncodingTestDocument(
+  val no_annotation_field: String,
+  @BarberField()
+  val default_field: String,
+  @BarberField(encoding = BarberFieldEncoding.STRING_HTML)
+  val html_field: String,
+  @BarberField(encoding = BarberFieldEncoding.STRING_PLAINTEXT)
+  val plaintext_field: String
+) : Document
+
+// Rendered with all fields set to `You purchased 100 shares of McDonald's.`
+EncodingTestDocument(
+    no_annotation_field = "You purchased 100 shares of McDonald&#39;s.",
+    default_field = "You purchased 100 shares of McDonald&#39;s.",
+    html_field = "You purchased 100 shares of McDonald&#39;s.",
+    // Note: no character escaping on the plaintext field
+    plaintext_field = "You purchased 100 shares of McDonald's."
+)
+```
+
 ## Locale
 
 Barber supports installation and resolution of multiple Locales for each `DocumentTemplate`.

--- a/barber/build.gradle
+++ b/barber/build.gradle
@@ -27,4 +27,3 @@ afterEvaluate { project ->
     outputFormat = 'gfm'
   }
 }
-

--- a/barber/src/main/kotlin/app/cash/barber/BarberMustacheFactoryProvider.kt
+++ b/barber/src/main/kotlin/app/cash/barber/BarberMustacheFactoryProvider.kt
@@ -1,0 +1,17 @@
+package app.cash.barber
+
+import app.cash.barber.models.BarberFieldEncoding
+import app.cash.barber.models.Document
+import com.github.mustachejava.DefaultMustacheFactory
+
+/**
+ * Provides a MustacheFactory depending on the [BarberFieldEncoding] of the [Document] field
+ */
+object BarberMustacheFactoryProvider {
+  private val defaultMustacheFactory = DefaultMustacheFactory()
+  private val barberPlaintextMustacheFactory = BarberPlaintextMustacheFactory()
+  fun get(encoding: BarberFieldEncoding?) = when (encoding) {
+    BarberFieldEncoding.STRING_PLAINTEXT -> barberPlaintextMustacheFactory
+    BarberFieldEncoding.STRING_HTML, null -> defaultMustacheFactory
+  }
+}

--- a/barber/src/main/kotlin/app/cash/barber/BarberPlaintextMustacheFactory.kt
+++ b/barber/src/main/kotlin/app/cash/barber/BarberPlaintextMustacheFactory.kt
@@ -1,0 +1,16 @@
+package app.cash.barber
+
+import app.cash.barber.models.BarberFieldEncoding.STRING_PLAINTEXT
+import com.github.mustachejava.DefaultMustacheFactory
+import com.github.mustachejava.MustacheException
+import java.io.Writer
+
+/**
+ * Mustache Factory that handles [STRING_PLAINTEXT] fields and doesn't apply the HTML escaping
+ *  present in [DefaultMustacheFactory]
+ */
+class BarberPlaintextMustacheFactory : DefaultMustacheFactory() {
+  override fun encode(value: String?, writer: Writer?) {
+    writer?.write(value) ?: throw MustacheException("Null Writer. Failed to encode value: $value")
+  }
+}

--- a/barber/src/main/kotlin/app/cash/barber/RealBarber.kt
+++ b/barber/src/main/kotlin/app/cash/barber/RealBarber.kt
@@ -19,13 +19,13 @@ internal class RealBarber<C : DocumentData, D : Document>(
 
     // Render each field of DocumentTemplate with passed in DocumentData context
     // Some of these fields now will be null since any missing fields will have been added with null values
-    val renderedDocumentDataFields: Map<String, String?> = documentTemplateFields.mapValues {
+    val renderedDocumentTemplateFields: Map<String, String?> = documentTemplateFields.mapValues {
       it.value.renderMustache(documentData)
     }
 
     // Zips the KParameters with corresponding rendered values from DocumentTemplate
     val documentParametersByName = documentConstructor.asParameterNames()
-    val parameters = renderedDocumentDataFields.filter {
+    val parameters = renderedDocumentTemplateFields.filter {
       documentParametersByName.containsKey(it.key)
     }.mapKeys {
       documentParametersByName.getValue(it.key)

--- a/barber/src/main/kotlin/app/cash/barber/RealBarbershop.kt
+++ b/barber/src/main/kotlin/app/cash/barber/RealBarbershop.kt
@@ -39,6 +39,10 @@ internal class RealBarbershop(
           |DocumentData [$documentDataClass] and corresponding DocumentTemplate(s) are not installed in Barbershop
         """.trimMargin())
       }
+      if (problems.isEmpty()) {
+        problems.add("Failed to get Barber<$documentDataClass, $documentClass>, unknown error")
+      }
+
       throw BarberException(problems)
     }
     return barber as Barber<DD, D>

--- a/barber/src/main/kotlin/app/cash/barber/models/BarberField.kt
+++ b/barber/src/main/kotlin/app/cash/barber/models/BarberField.kt
@@ -1,0 +1,9 @@
+package app.cash.barber.models
+
+import com.github.mustachejava.MustacheFactory
+
+/**
+ * Document fields annotated will be rendered with a [MustacheFactory] corresponding to the
+ *   [BarberFieldEncoding].
+ */
+annotation class BarberField(val encoding: BarberFieldEncoding = BarberFieldEncoding.STRING_HTML)

--- a/barber/src/main/kotlin/app/cash/barber/models/BarberFieldEncoding.kt
+++ b/barber/src/main/kotlin/app/cash/barber/models/BarberFieldEncoding.kt
@@ -1,0 +1,8 @@
+package app.cash.barber.models
+
+/**
+ * Used in [BarberField] annotation on Document fields to specify the encoding to render using.
+ */
+enum class BarberFieldEncoding {
+  STRING_HTML, STRING_PLAINTEXT
+}

--- a/barber/src/main/kotlin/app/cash/barber/models/CompiledDocumentTemplate.kt
+++ b/barber/src/main/kotlin/app/cash/barber/models/CompiledDocumentTemplate.kt
@@ -1,6 +1,5 @@
 package app.cash.barber.models
 
-import app.cash.barber.asString
 import com.github.mustachejava.Mustache
 import kotlin.reflect.KClass
 
@@ -15,13 +14,4 @@ data class CompiledDocumentTemplate(
   val source: KClass<out DocumentData>,
   val targets: Set<KClass<out Document>>,
   val locale: Locale
-) {
-  override fun toString(): String = toDocumentTemplate().toString()
-
-  fun toDocumentTemplate() = DocumentTemplate(
-      fields = this.fields.mapValues { it.value.asString() },
-      source = this.source,
-      targets = this.targets,
-      locale = this.locale
-  )
-}
+)

--- a/barber/src/main/kotlin/app/cash/barber/models/DocumentTemplate.kt
+++ b/barber/src/main/kotlin/app/cash/barber/models/DocumentTemplate.kt
@@ -1,10 +1,11 @@
 package app.cash.barber.models
 
+import app.cash.barber.BarberMustacheFactoryProvider
 import app.cash.barber.asParameterNames
 import com.github.mustachejava.Mustache
-import com.github.mustachejava.MustacheFactory
 import java.io.StringReader
 import kotlin.reflect.KClass
+import kotlin.reflect.KParameter
 import kotlin.reflect.full.primaryConstructor
 
 /**
@@ -35,12 +36,18 @@ data class DocumentTemplate(
     |)
   """.trimMargin()
 
-  fun compile(mustacheFactory: MustacheFactory): CompiledDocumentTemplate {
+  fun compile(
+    mustacheFactoryProvider: BarberMustacheFactoryProvider,
+    installedFieldKeyDocumentKParameterMap: Map<String, Pair<KClass<out Document>, KParameter>>
+  ): CompiledDocumentTemplate {
     // Pre-compile Mustache templates
-    val documentDataFields: MutableMap<String, Mustache?> =
-        fields.mapValues {
-          mustacheFactory.compile(StringReader(it.value), it.value)
-        }.toMutableMap()
+    val documentTemplateFields: MutableMap<String, Mustache?> =
+      fields.mapValues { (fieldKey, fieldValue) ->
+        // Render using a MustacheFactory that will respect any field BarberFieldEncoding annotations
+        val documentFieldAnnotations = installedFieldKeyDocumentKParameterMap[fieldKey]?.second?.annotations
+        val barberField = documentFieldAnnotations?.find { it is BarberField } as BarberField?
+        mustacheFactoryProvider.get(barberField?.encoding).compile(StringReader(fieldValue), fieldValue)
+      }.toMutableMap()
 
     // Find missing fields in DocumentTemplate
     // Missing fields occur when a nullable field in Document is not an included key in the DocumentTemplate fields
@@ -59,12 +66,13 @@ data class DocumentTemplate(
     }.toSet()
 
     // Initialize keys for missing nullable fields in DocumentTemplate
-    combinedDocumentParameterNames.mapNotNull { documentDataFields.putIfAbsent(it, null) }
+    combinedDocumentParameterNames.mapNotNull { documentTemplateFields.putIfAbsent(it, null) }
 
     return CompiledDocumentTemplate(
-        fields = documentDataFields,
+        fields = documentTemplateFields,
         source = source,
         targets = targets,
-        locale = locale)
+        locale = locale
+    )
   }
 }

--- a/barber/src/test/kotlin/app/cash/barber/BarberExceptionTest.kt
+++ b/barber/src/test/kotlin/app/cash/barber/BarberExceptionTest.kt
@@ -43,4 +43,24 @@ class BarberExceptionTest {
       |
     """.trimMargin(), exception.toString())
   }
+
+  @Test
+  fun `null exception`() {
+    val exception = assertFailsWith<BarberException> { throw BarberException() }
+    assertEquals("""
+      |Unknown BarberException
+    """.trimMargin(), exception.toString())
+  }
+
+  @Test
+  fun `exception with message`() {
+    val exception = assertFailsWith<BarberException> { throw BarberException(listOf(
+        "Failed to get Barber<documentDataClass, documentClass>, unknown error"
+    )) }
+    assertEquals("""
+      |Errors
+      |1) Failed to get Barber<documentDataClass, documentClass>, unknown error
+      |
+    """.trimMargin(), exception.toString())
+  }
 }

--- a/barber/src/test/kotlin/app/cash/barber/BarberTest.kt
+++ b/barber/src/test/kotlin/app/cash/barber/BarberTest.kt
@@ -1,8 +1,12 @@
 package app.cash.barber
 
+import app.cash.barber.examples.EncodingTestDocument
+import app.cash.barber.examples.InvestmentPurchase
 import app.cash.barber.examples.RecipientReceipt
 import app.cash.barber.examples.TransactionalEmailDocument
 import app.cash.barber.examples.TransactionalSmsDocument
+import app.cash.barber.examples.investmentPurchasePlaintextSmsDocumentTemplateEN_US
+import app.cash.barber.examples.mcDonaldsInvestmentPurchase
 import app.cash.barber.examples.recipientReceiptSmsDocumentTemplateEN_CA
 import app.cash.barber.examples.recipientReceiptSmsDocumentTemplateEN_GB
 import app.cash.barber.examples.recipientReceiptSmsDocumentTemplateEN_US
@@ -204,6 +208,26 @@ class BarberTest {
     assertThat(spec).isEqualTo(
         TransactionalSmsDocument(
             sms_body = "Sandy Winchester sent you \$50. It will be available at 2019-05-21T16:02:00Z. Cancel here: https://cash.app/cancel/123"
+        )
+    )
+  }
+
+  @Test
+  fun `BarberField annotation configures Mustache render encoding per field`() {
+    val barber = BarbershopBuilder()
+        .installDocument<EncodingTestDocument>()
+        .installDocumentTemplate<InvestmentPurchase>(investmentPurchasePlaintextSmsDocumentTemplateEN_US)
+        .build()
+
+    val spec = barber.getBarber<InvestmentPurchase, EncodingTestDocument>()
+        .render(mcDonaldsInvestmentPurchase, EN_US)
+
+    assertThat(spec).isEqualTo(
+        EncodingTestDocument(
+            no_annotation_field = "You purchased 100 shares of McDonald&#39;s.",
+            default_field = "You purchased 100 shares of McDonald&#39;s.",
+            html_field = "You purchased 100 shares of McDonald&#39;s.",
+            plaintext_field = "You purchased 100 shares of McDonald's."
         )
     )
   }

--- a/barber/src/test/kotlin/app/cash/barber/examples/EncodingTestDocument.kt
+++ b/barber/src/test/kotlin/app/cash/barber/examples/EncodingTestDocument.kt
@@ -1,0 +1,18 @@
+package app.cash.barber.examples
+
+import app.cash.barber.models.BarberField
+import app.cash.barber.models.BarberFieldEncoding
+import app.cash.barber.models.Document
+
+/**
+ * Test document to exercise [BarberFieldEncoding]
+ */
+data class EncodingTestDocument(
+  val no_annotation_field: String,
+  @BarberField()
+  val default_field: String,
+  @BarberField(encoding = BarberFieldEncoding.STRING_HTML)
+  val html_field: String,
+  @BarberField(encoding = BarberFieldEncoding.STRING_PLAINTEXT)
+  val plaintext_field: String
+) : Document

--- a/barber/src/test/kotlin/app/cash/barber/examples/InvestmentPurchased.kt
+++ b/barber/src/test/kotlin/app/cash/barber/examples/InvestmentPurchased.kt
@@ -1,0 +1,13 @@
+package app.cash.barber.examples
+
+import app.cash.barber.models.DocumentData
+
+data class InvestmentPurchase(
+  val shares: String,
+  val ticker: String
+) : DocumentData
+
+val mcDonaldsInvestmentPurchase = InvestmentPurchase(
+    shares = "100",
+    ticker = "McDonald's"
+)

--- a/barber/src/test/kotlin/app/cash/barber/examples/ShadowSmsDocument.kt
+++ b/barber/src/test/kotlin/app/cash/barber/examples/ShadowSmsDocument.kt
@@ -1,0 +1,10 @@
+package app.cash.barber.examples
+
+import app.cash.barber.models.Document
+
+/**
+ * An example Document that shadows field names of [TransactionalSmsDocument]
+ */
+data class ShadowSmsDocument(
+  val sms_body: String
+) : Document

--- a/barber/src/test/kotlin/app/cash/barber/examples/TestFixtures.kt
+++ b/barber/src/test/kotlin/app/cash/barber/examples/TestFixtures.kt
@@ -14,6 +14,18 @@ val recipientReceiptSmsDocumentTemplateEN_US = DocumentTemplate(
     locale = EN_US
 )
 
+val investmentPurchasePlaintextSmsDocumentTemplateEN_US = DocumentTemplate(
+    fields = mapOf(
+        "no_annotation_field" to "You purchased {{ shares }} shares of {{ ticker }}.",
+        "default_field" to "You purchased {{ shares }} shares of {{ ticker }}.",
+        "html_field" to "You purchased {{ shares }} shares of {{ ticker }}.",
+        "plaintext_field" to "You purchased {{ shares }} shares of {{ ticker }}."
+    ),
+    source = InvestmentPurchase::class,
+    targets = setOf(EncodingTestDocument::class),
+    locale = EN_US
+)
+
 val recipientReceiptSmsEmailDocumentTemplateEN_US = DocumentTemplate(
     fields = mapOf(
         "subject" to "{{sender}} sent you {{amount}}",

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,7 +1,6 @@
 // Auto-generated from polyrepo's master-dependencies.json. Update via polyrepo dep-add and polyrepo dep-upgrade.
 ext.dep = [
   "assertj": "org.assertj:assertj-core:3.15.0",
-  "gradleBuildScan": "com.gradle:build-scan-plugin:2.3",
   "guava": "com.google.guava:guava:28.2-jre",
   "guice": "com.google.inject:guice:4.2.3",
   "guiceMultibindings": "com.google.inject.extensions:guice-multibindings:4.2.3",
@@ -11,7 +10,6 @@ ext.dep = [
   "jacksonKotlin": "com.fasterxml.jackson.module:jackson-module-kotlin:2.10.2",
   "junitApi": "org.junit.jupiter:junit-jupiter-api:5.6.0",
   "junitEngine": "org.junit.jupiter:junit-jupiter-engine:5.6.0",
-  "junitGradlePlugin": "org.junit.platform:junit-platform-gradle-plugin:1.2.0",
   "junitParams": "org.junit.jupiter:junit-jupiter-params:5.6.0",
   "kotlinGradlePlugin": "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.71",
   "kotlinReflection": "org.jetbrains.kotlin:kotlin-reflect:1.3.71",


### PR DESCRIPTION
* Barber now knows how to parse a `@BarberField(encoding = ...)` annotation on a `val` in a `Document` and render using a MustacheFactory that corresponds to the encoding type.
* Adding `@BarberField(encoding = BarberFieldEncoding.STRING_PLAINTEXT)` to respective plaintext `Document` fields will fix #39

Docs & Example
---

The `@BarberField` annotation can be used on Document class `val` fields to declare that the field should be rendered and treated according to a specific `BarberFieldEncoding`.

`BarberFieldEncoding` can be for now `STRING_HTML` or `STRING_PLAINTEXT`. 

By default, all fields are treated as `STRING_HTML` and have common HTML escaping of characters for safety. 

When a field is annotated as `STRING_PLAINTEXT`, characters will not be escaped.

```kotlin
data class EncodingTestDocument(
  val no_annotation_field: String,
  @BarberField()
  val default_field: String,
  @BarberField(encoding = BarberFieldEncoding.STRING_HTML)
  val html_field: String,
  @BarberField(encoding = BarberFieldEncoding.STRING_PLAINTEXT)
  val plaintext_field: String
) : Document

// Rendered with all fields set to `You purchased 100 shares of McDonald's.`
EncodingTestDocument(
    no_annotation_field = "You purchased 100 shares of McDonald&#39;s.",
    default_field = "You purchased 100 shares of McDonald&#39;s.",
    html_field = "You purchased 100 shares of McDonald&#39;s.",
    // Note: no character escaping on the plaintext field
    plaintext_field = "You purchased 100 shares of McDonald's."
)
```