### PR TITLE
[CLOSES #48][CLOSES #46] Add encoding configuration & remove shadow field name validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,6 @@ A Java style Builder that installs all of the above Barber elements and returns 
 - Install `Document` with `.installDocument<TransactionalSmsDocument>()`
 - Optionally set a custom `LocaleResolver` with `.setLocaleResolver(MapleSyrupOrFirstLocaleResolver())`
 - Optionally set a default `BarberFieldEncoding` for non-annotated Document fields with `.setDefaultBarberFieldEncoding(STRING_PLAINTEXT)`
-- Optionally configure validation strictness of field name shadowing between `Documents` with `.allowShadowedDocumentFieldNames(setOf("notificationId"))`
 - Optionally configure warning validation strictness with `.setWarningsAsErrors()`
 - Return the finished Barbershop with `.build()` as the final method call on BarbershopBuilder.
 

--- a/README.md
+++ b/README.md
@@ -145,7 +145,10 @@ A Java style Builder that installs all of the above Barber elements and returns 
 
 - Install `DocumentData` and `DocumentTemplate` pairs with `.installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_US)`.
 - Install `Document` with `.installDocument<TransactionalSmsDocument>()`
-- Set a custom `LocaleResolver` with `.setLocaleResolver(MapleSyrupOrFirstLocaleResolver())`
+- Optionally set a custom `LocaleResolver` with `.setLocaleResolver(MapleSyrupOrFirstLocaleResolver())`
+- Optionally set a default `BarberFieldEncoding` for non-annotated Document fields with `.setDefaultBarberFieldEncoding(STRING_PLAINTEXT)`
+- Optionally configure validation strictness of field name shadowing between `Documents` with `.allowShadowedDocumentFieldNames(setOf("notificationId"))`
+- Optionally configure warning validation strictness with `.setWarningsAsErrors()`
 - Return the finished Barbershop with `.build()` as the final method call on BarbershopBuilder.
 
 ```kotlin

--- a/barber/src/main/kotlin/app/cash/barber/BarberMustacheFactoryProvider.kt
+++ b/barber/src/main/kotlin/app/cash/barber/BarberMustacheFactoryProvider.kt
@@ -7,11 +7,13 @@ import com.github.mustachejava.DefaultMustacheFactory
 /**
  * Provides a MustacheFactory depending on the [BarberFieldEncoding] of the [Document] field
  */
-object BarberMustacheFactoryProvider {
+class BarberMustacheFactoryProvider(
+  private val defaultBarberFieldEncoding: BarberFieldEncoding = BarberFieldEncoding.STRING_HTML
+) {
   private val defaultMustacheFactory = DefaultMustacheFactory()
   private val barberPlaintextMustacheFactory = BarberPlaintextMustacheFactory()
-  fun get(encoding: BarberFieldEncoding?) = when (encoding) {
+  fun get(encoding: BarberFieldEncoding?) = when (encoding ?: defaultBarberFieldEncoding) {
     BarberFieldEncoding.STRING_PLAINTEXT -> barberPlaintextMustacheFactory
-    BarberFieldEncoding.STRING_HTML, null -> defaultMustacheFactory
+    BarberFieldEncoding.STRING_HTML -> defaultMustacheFactory
   }
 }

--- a/barber/src/main/kotlin/app/cash/barber/Barbershop.kt
+++ b/barber/src/main/kotlin/app/cash/barber/Barbershop.kt
@@ -58,17 +58,6 @@ interface Barbershop {
     fun setDefaultBarberFieldEncoding(encoding: BarberFieldEncoding): Builder
 
     /**
-     * Allows Documents to have common field names. Useful when documents of a similar type share a
-     * common identifier field name that has no annotation or per Document configuration that would
-     * make shadowing a problem. By default, no field names are allowed to be shadowed.
-     *
-     * @param namesAllowedToBeShadowed
-     *  * Configured with an empty set, any field name is allowed to be shadowed across documents.
-     *  * Used with a set of names, only the names in the set are allowed to be shadowed.
-     */
-    fun allowShadowedDocumentFieldNames(namesAllowedToBeShadowed: Set<String> = setOf()): Builder
-
-    /**
      * Validates that all templates, document datas, and documents are mutually consistent and
      * returns a new Barbershop.
      */

--- a/barber/src/main/kotlin/app/cash/barber/Barbershop.kt
+++ b/barber/src/main/kotlin/app/cash/barber/Barbershop.kt
@@ -1,5 +1,6 @@
 package app.cash.barber
 
+import app.cash.barber.models.BarberFieldEncoding
 import app.cash.barber.models.BarberKey
 import app.cash.barber.models.Document
 import app.cash.barber.models.DocumentData
@@ -49,6 +50,23 @@ interface Barbershop {
      * only errors, not warnings, lead to fatal BarberException during validation.
      */
     fun setWarningsAsErrors(): Builder
+
+    /**
+     * Configures this barbershop to use a given [BarberFieldEncoding] when no annotation to override
+     * is present. By default, [BarberFieldEncoding.STRING_HTML] is used.
+     */
+    fun setDefaultBarberFieldEncoding(encoding: BarberFieldEncoding): Builder
+
+    /**
+     * Allows Documents to have common field names. Useful when documents of a similar type share a
+     * common identifier field name that has no annotation or per Document configuration that would
+     * make shadowing a problem. By default, no field names are allowed to be shadowed.
+     *
+     * @param namesAllowedToBeShadowed
+     *  * Configured with an empty set, any field name is allowed to be shadowed across documents.
+     *  * Used with a set of names, only the names in the set are allowed to be shadowed.
+     */
+    fun allowShadowedDocumentFieldNames(namesAllowedToBeShadowed: Set<String> = setOf()): Builder
 
     /**
      * Validates that all templates, document datas, and documents are mutually consistent and

--- a/barber/src/main/kotlin/app/cash/barber/RealBarber.kt
+++ b/barber/src/main/kotlin/app/cash/barber/RealBarber.kt
@@ -5,34 +5,53 @@ import app.cash.barber.models.Document
 import app.cash.barber.models.DocumentData
 import app.cash.barber.models.Locale
 import com.github.mustachejava.Mustache
+import com.google.common.collect.Table
 import java.io.StringWriter
-import kotlin.reflect.KFunction
+import kotlin.reflect.KClass
+import kotlin.reflect.KParameter
+import kotlin.reflect.full.primaryConstructor
 
 internal class RealBarber<C : DocumentData, D : Document>(
-  private val documentConstructor: KFunction<D>,
+  private val document: KClass<out D>,
+  private val installedDocuments: Table<String, KClass<out Document>, KParameter>,
   private val compiledDocumentTemplateLocales: Map<Locale, CompiledDocumentTemplate>,
   private val localeResolver: LocaleResolver
 ) : Barber<C, D> {
   override fun render(documentData: C, locale: Locale): D {
     val documentTemplate = localeResolver.resolve(locale, compiledDocumentTemplateLocales)
-    val documentTemplateFields = documentTemplate.fields
 
     // Render each field of DocumentTemplate with passed in DocumentData context
     // Some of these fields now will be null since any missing fields will have been added with null values
-    val renderedDocumentTemplateFields: Map<String, String?> = documentTemplateFields.mapValues {
-      it.value.renderMustache(documentData)
-    }
+    val renderedDocumentTemplateFields: Map<String, String?> =
+        documentTemplate.fields.column(document)
+            .mapValues {
+              it.value.renderMustache(documentData)
+            }
 
     // Zips the KParameters with corresponding rendered values from DocumentTemplate
-    val documentParametersByName = documentConstructor.asParameterNames()
-    val parameters = renderedDocumentTemplateFields.filter {
-      documentParametersByName.containsKey(it.key)
-    }.mapKeys {
-      documentParametersByName.getValue(it.key)
-    }
+    val parameters = installedDocuments.column(document).map { (fieldName, kParameter) ->
+      kParameter to when {
+        renderedDocumentTemplateFields.containsKey(fieldName) -> {
+          renderedDocumentTemplateFields.getValue(fieldName)
+        }
+        // Initialize any nullable not included fields as null
+        kParameter.type.isMarkedNullable -> {
+          null
+        }
+        // This case should never be hit because it is covered in BarbershopBuilder validation
+        else -> {
+          throw BarberException(errors = listOf("""
+            |RealBarber unable to render 
+            |DocumentData: $documentData
+            |DocumentTemplate: $documentTemplate
+            |Document: $document
+            |""".trimMargin()))
+        }
+      }
+    }.toMap()
 
     // Build the Document instance with the rendered DocumentTemplate parameters
-    return documentConstructor.callBy(parameters)
+    return document.primaryConstructor!!.callBy(parameters)
   }
 
   /* Render a pre-compiled nullable Mustache template */

--- a/barber/src/main/kotlin/app/cash/barber/Utilities.kt
+++ b/barber/src/main/kotlin/app/cash/barber/Utilities.kt
@@ -1,29 +1,7 @@
 package app.cash.barber
 
-import app.cash.barber.models.CompiledDocumentTemplate
-import app.cash.barber.models.Locale
 import com.github.mustachejava.Mustache
 import kotlin.reflect.KFunction
-
-internal fun Map<String, Mustache?>.asFieldCodesMap() =
-    mapValues { (_, template: Mustache?) ->
-      template?.codes?.mapNotNull { it.name }?.toSet() ?: setOf()
-    }
-
-internal fun Map<*, Set<String>>.reduceSet(): Set<String> =
-    if (values.isNotEmpty()) {
-      values.reduce { acc, codes -> acc + codes }
-    } else {
-      setOf()
-    }
-
-internal fun Map<String, Mustache?>.reducedFieldCodes() =
-    asFieldCodesMap().reduceSet()
-
-internal fun MutableMap<Locale, CompiledDocumentTemplate>.reducedFieldCodeSet() =
-    mapValues { (_, documentTemplate) ->
-      documentTemplate.fields.reducedFieldCodes()
-    }.reduceSet()
 
 internal fun KFunction<*>.asParameterNames() = parameters.associateBy { it.name }
 

--- a/barber/src/main/kotlin/app/cash/barber/models/CompiledDocumentTemplate.kt
+++ b/barber/src/main/kotlin/app/cash/barber/models/CompiledDocumentTemplate.kt
@@ -1,6 +1,7 @@
 package app.cash.barber.models
 
 import com.github.mustachejava.Mustache
+import com.google.common.collect.Table
 import kotlin.reflect.KClass
 
 /**
@@ -10,8 +11,34 @@ import kotlin.reflect.KClass
  *  [Document] (even for [Document] keys that are nullable) and improve Mustache execution runtime.
  */
 data class CompiledDocumentTemplate(
-  val fields: Map<String, Mustache?>,
+  val fields: Table<String, KClass<out Document>, Mustache?>,
   val source: KClass<out DocumentData>,
   val targets: Set<KClass<out Document>>,
   val locale: Locale
-)
+) {
+  /** Return map of fieldName to set of Mustache codes in the field template */
+  fun reducedFieldCodeMap() = fields.columnMap().values.map { fieldNameMustacheMap ->
+    fieldNameMustacheMap.mapValues { (_, template: Mustache?) ->
+      template?.codes?.mapNotNull { it.name }?.toSet() ?: setOf()
+    }
+  }.let {
+    if (it.isNotEmpty()) {
+      return@let it.reduce { acc, codes -> acc + codes }
+    } else {
+      return@let mapOf<String, Set<String>>()
+    }
+  }
+
+  /** Returns set of all Mustache codes in DocumentTemplate */
+  fun reducedFieldCodeSet() = reducedFieldCodeMap().reduceToValuesSet()
+
+  companion object {
+    /** Returns values from a Map as an aggregated set */
+    fun Map<*, Set<String>>.reduceToValuesSet(): Set<String> =
+        if (values.isNotEmpty()) {
+          values.reduce { acc, codes -> acc + codes }
+        } else {
+          setOf()
+        }
+  }
+}

--- a/barber/src/test/kotlin/app/cash/barber/BarberTest.kt
+++ b/barber/src/test/kotlin/app/cash/barber/BarberTest.kt
@@ -5,7 +5,7 @@ import app.cash.barber.examples.InvestmentPurchase
 import app.cash.barber.examples.RecipientReceipt
 import app.cash.barber.examples.TransactionalEmailDocument
 import app.cash.barber.examples.TransactionalSmsDocument
-import app.cash.barber.examples.investmentPurchasePlaintextSmsDocumentTemplateEN_US
+import app.cash.barber.examples.investmentPurchaseEncodingDocumentTemplateEN_US
 import app.cash.barber.examples.mcDonaldsInvestmentPurchase
 import app.cash.barber.examples.recipientReceiptSmsDocumentTemplateEN_CA
 import app.cash.barber.examples.recipientReceiptSmsDocumentTemplateEN_GB
@@ -216,7 +216,7 @@ class BarberTest {
   fun `BarberField annotation configures Mustache render encoding per field`() {
     val barber = BarbershopBuilder()
         .installDocument<EncodingTestDocument>()
-        .installDocumentTemplate<InvestmentPurchase>(investmentPurchasePlaintextSmsDocumentTemplateEN_US)
+        .installDocumentTemplate<InvestmentPurchase>(investmentPurchaseEncodingDocumentTemplateEN_US)
         .build()
 
     val spec = barber.getBarber<InvestmentPurchase, EncodingTestDocument>()

--- a/barber/src/test/kotlin/app/cash/barber/examples/ShadowEncodingEverythingPlaintextTestDocument.kt
+++ b/barber/src/test/kotlin/app/cash/barber/examples/ShadowEncodingEverythingPlaintextTestDocument.kt
@@ -5,15 +5,17 @@ import app.cash.barber.models.BarberFieldEncoding
 import app.cash.barber.models.Document
 
 /**
- * Test document to exercise shadowed field names
+ * Test document to exercise shadowed field names with different [BarberFieldEncoding]
  */
-data class ShadowEncodingTestDocument(
+data class ShadowEncodingEverythingPlaintextTestDocument(
+  @BarberField(encoding = BarberFieldEncoding.STRING_PLAINTEXT)
   val no_annotation_field: String,
-  @BarberField()
+  @BarberField(encoding = BarberFieldEncoding.STRING_PLAINTEXT)
   val default_field: String,
-  @BarberField(encoding = BarberFieldEncoding.STRING_HTML)
+  @BarberField(encoding = BarberFieldEncoding.STRING_PLAINTEXT)
   val html_field: String,
   @BarberField(encoding = BarberFieldEncoding.STRING_PLAINTEXT)
   val plaintext_field: String,
+  @BarberField(encoding = BarberFieldEncoding.STRING_PLAINTEXT)
   val non_shadow_field: String
 ) : Document

--- a/barber/src/test/kotlin/app/cash/barber/examples/ShadowEncodingTestDocument.kt
+++ b/barber/src/test/kotlin/app/cash/barber/examples/ShadowEncodingTestDocument.kt
@@ -1,0 +1,19 @@
+package app.cash.barber.examples
+
+import app.cash.barber.models.BarberField
+import app.cash.barber.models.BarberFieldEncoding
+import app.cash.barber.models.Document
+
+/**
+ * Test document to exercise shadowed field names
+ */
+data class ShadowEncodingTestDocument(
+  val no_annotation_field: String,
+  @BarberField()
+  val default_field: String,
+  @BarberField(encoding = BarberFieldEncoding.STRING_HTML)
+  val html_field: String,
+  @BarberField(encoding = BarberFieldEncoding.STRING_PLAINTEXT)
+  val plaintext_field: String,
+  val non_shadow_field: String
+) : Document

--- a/barber/src/test/kotlin/app/cash/barber/examples/TestFixtures.kt
+++ b/barber/src/test/kotlin/app/cash/barber/examples/TestFixtures.kt
@@ -14,7 +14,7 @@ val recipientReceiptSmsDocumentTemplateEN_US = DocumentTemplate(
     locale = EN_US
 )
 
-val investmentPurchasePlaintextSmsDocumentTemplateEN_US = DocumentTemplate(
+val investmentPurchaseEncodingDocumentTemplateEN_US = DocumentTemplate(
     fields = mapOf(
         "no_annotation_field" to "You purchased {{ shares }} shares of {{ ticker }}.",
         "default_field" to "You purchased {{ shares }} shares of {{ ticker }}.",
@@ -23,6 +23,19 @@ val investmentPurchasePlaintextSmsDocumentTemplateEN_US = DocumentTemplate(
     ),
     source = InvestmentPurchase::class,
     targets = setOf(EncodingTestDocument::class),
+    locale = EN_US
+)
+
+val investmentPurchaseShadowEncodingDocumentTemplateEN_US = DocumentTemplate(
+    fields = mapOf(
+        "no_annotation_field" to "You purchased {{ shares }} shares of {{ ticker }}.",
+        "default_field" to "You purchased {{ shares }} shares of {{ ticker }}.",
+        "html_field" to "You purchased {{ shares }} shares of {{ ticker }}.",
+        "plaintext_field" to "You purchased {{ shares }} shares of {{ ticker }}.",
+        "non_shadow_field" to "You purchased {{ shares }} shares of {{ ticker }}."
+    ),
+    source = InvestmentPurchase::class,
+    targets = setOf(EncodingTestDocument::class, ShadowEncodingTestDocument::class),
     locale = EN_US
 )
 

--- a/barber/src/test/kotlin/app/cash/barber/examples/TestFixtures.kt
+++ b/barber/src/test/kotlin/app/cash/barber/examples/TestFixtures.kt
@@ -35,7 +35,7 @@ val investmentPurchaseShadowEncodingDocumentTemplateEN_US = DocumentTemplate(
         "non_shadow_field" to "You purchased {{ shares }} shares of {{ ticker }}."
     ),
     source = InvestmentPurchase::class,
-    targets = setOf(EncodingTestDocument::class, ShadowEncodingTestDocument::class),
+    targets = setOf(EncodingTestDocument::class, ShadowEncodingEverythingPlaintextTestDocument::class),
     locale = EN_US
 )
 


### PR DESCRIPTION
Other than added tests and documentation, this refactor is ~roughly net negative and drastically simplifies some of the core Barber logic in CompiledDocumentTemplate and RealBarber, while additionally removing the annoying Document shadow field name validation by a more capable implementation.

It also adds a method on BarbershopBuilder to allow finer grain configuration of default BarberFieldEncoding for non-annotated fields.