### PR TITLE
Add Barber API protos to support more dynamic functionality

### DIFF
--- a/barber/build.gradle
+++ b/barber/build.gradle
@@ -14,6 +14,8 @@ dependencies {
   implementation dep.moshiKotlin
   implementation dep.okio
   implementation dep.mustacheCompiler
+  implementation dep.wireMoshiAdapter
+  implementation dep.wireRuntime
 
   testImplementation dep.assertj
   testImplementation dep.junitApi

--- a/barber/src/main/proto/app/cash/barber/api/BarberApi.proto
+++ b/barber/src/main/proto/app/cash/barber/api/BarberApi.proto
@@ -1,0 +1,54 @@
+syntax = "proto2";
+package app.cash.barber.api;
+
+option java_package = "app.cash.protos.barber.api";
+
+import "google/protobuf/duration.proto";
+import "google/protobuf/timestamp.proto";
+
+/* Provides the necessary context to render a template matching template_token */
+message BarberDocumentData {
+  /* A representation of a field that supports a dynamic value type */
+  message Field {
+    /* Context variable name that is used in templates */
+    optional string name = 1;
+    /* Context variable in a supported type (string, integer, duration, instant) */
+    oneof value {
+      string string = 2;
+      int64 integer = 3;
+      google.protobuf.Duration duration = 4;
+      google.protobuf.Timestamp instant = 5;
+      // TODO add amount to support Money
+    }
+  }
+
+  /*
+   * A unique identifier for the corresponding DocumentTemplate that this DocumentData provides
+   * necessary context to render
+   */
+  optional string template_token = 1;
+  /* The context values required to render a DocumentTemplate of the given template_token */
+  repeated Field fields = 2;
+}
+
+/* Contains the templates for a given locale to render target Documents */
+message BarberDocumentTemplate {
+  /* A template field within a DocumentTemplate */
+  message Field {
+    /* Field name matches one of the fields of the target Document */
+    optional string name = 1;
+    /* A Mustache compatible template string with values filled in by DocumentData */
+    optional string template = 2;
+  }
+
+  /* A unique identifier used for lookup */
+  optional string template_token = 1;
+  /* An auto-incrementing integer to identify a unique version of the same DocumentTemplate */
+  optional int64 version = 2;
+  /* RFC 5646 locale language-region that the DocumentTemplate targets */
+  optional string locale = 3;
+  /* Fields that correspond to all fields of target Documents */
+  repeated Field fields = 4;
+  /* Document Tokens for the Documents that this DocumentTemplate can render */
+  repeated string target_documents = 5;
+}

--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,7 @@ buildscript {
     classpath dep.kotlinGradlePlugin
     classpath dep.spotlessPlugin
     classpath dep.mavenPublishGradlePlugin
+    classpath dep.wireGradlePlugin
   }
 }
 
@@ -26,6 +27,7 @@ subprojects { subProject ->
   apply plugin: 'kotlin'
   apply plugin: 'org.jetbrains.dokka'
   apply plugin: 'com.diffplug.gradle.spotless'
+  apply plugin: 'com.squareup.wire'
 
   compileKotlin {
     kotlinOptions {
@@ -42,6 +44,20 @@ subprojects { subProject ->
   compileJava {
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
+  }
+
+  sourceSets {
+    main.resources.srcDirs += "src/main/proto/"
+
+    main.kotlin {
+      srcDirs += "$buildDir/generated/source/wire/"
+    }
+  }
+
+  wire {
+    kotlin {
+      javaInterop = true
+    }
   }
 
   repositories {

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -26,5 +26,8 @@ ext.dep = [
   "shadowJarPlugin": "com.github.jengelman.gradle.plugins:shadow:5.1.0",
   "spotlessPlugin": "com.diffplug.spotless:spotless-plugin-gradle:3.25.0",
   "tracingJaeger": "com.uber.jaeger:jaeger-core:0.27.0",
+  "wireGradlePlugin": "com.squareup.wire:wire-gradle-plugin:3.4.0",
+  "wireMoshiAdapter": "com.squareup.wire:wire-moshi-adapter:3.4.0",
+  "wireRuntime": "com.squareup.wire:wire-runtime:3.4.0",
 ]
 // Auto-generated from polyrepo's master-dependencies.json. Update via polyrepo dep-add and polyrepo dep-upgrade.

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip


### PR DESCRIPTION
Proto versions of `DocumentData` and `DocumentTemplate` will provide for easier usage of Barber within APIs and events that can leverage Wire for over-the-wire encoding.

Notably, `Document` will remain as a non-proto implemented Kotlin data class in order to provide more precise configuration of per field output encoding using `@BarberField` annotations.