### PR TITLE
Add further testing and helper methods for source and target signatures

### DIFF
--- a/barber/src/main/kotlin/app/cash/barber/BarberMustacheFactoryProvider.kt
+++ b/barber/src/main/kotlin/app/cash/barber/BarberMustacheFactoryProvider.kt
@@ -12,7 +12,7 @@ class BarberMustacheFactoryProvider(
 ) {
   private val defaultMustacheFactory = DefaultMustacheFactory()
   private val barberPlaintextMustacheFactory = BarberPlaintextMustacheFactory()
-  fun get(encoding: BarberFieldEncoding?) = when (encoding ?: defaultBarberFieldEncoding) {
+  fun get(encoding: BarberFieldEncoding? = null) = when (encoding ?: defaultBarberFieldEncoding) {
     BarberFieldEncoding.STRING_PLAINTEXT -> barberPlaintextMustacheFactory
     BarberFieldEncoding.STRING_HTML -> defaultMustacheFactory
   }

--- a/barber/src/main/kotlin/app/cash/barber/BarbershopBuilder.kt
+++ b/barber/src/main/kotlin/app/cash/barber/BarbershopBuilder.kt
@@ -6,7 +6,7 @@ import app.cash.barber.models.BarberSignature
 import app.cash.barber.models.BarberSignature.Companion.getBarberSignature
 import app.cash.barber.models.CompiledDocumentTemplate
 import app.cash.barber.models.CompiledDocumentTemplate.Companion.compileAndValidate
-import app.cash.barber.models.CompiledDocumentTemplate.Companion.getKey
+import app.cash.barber.models.CompiledDocumentTemplate.Companion.prettyPrint
 import app.cash.barber.models.Document
 import app.cash.barber.models.Locale
 import app.cash.barber.models.TemplateToken
@@ -70,7 +70,7 @@ class BarbershopBuilder : Barbershop.Builder {
         val installedVersions = localeVersions.keys.map { it.version }
         throw BarberException(errors = listOf("""
             |Attempted to install DocumentTemplate that will overwrite an already installed locale version
-            |${documentTemplate.getKey()}
+            |${documentTemplate.prettyPrint()}
             |
             |Already Installed DocumentTemplates
             |TemplateToken: $templateToken


### PR DESCRIPTION
This will let downstream library users better construct `DocumentTemplate` protos which need source and target BarberSignatures.