### PR TITLE
Default to String when Proto DocumentData has a null field with ambiguous Signature

### DIFF
--- a/barber/src/main/kotlin/app/cash/barber/models/BarberSignature.kt
+++ b/barber/src/main/kotlin/app/cash/barber/models/BarberSignature.kt
@@ -60,20 +60,12 @@ data class BarberSignature(
         mapOf<String, Type>()) { acc, field ->
       val key = field.key!!
       val value = when {
-        field.value_string != null -> {
-          Type.STRING
-        }
-        field.value_long != null -> {
-          Type.LONG
-        }
-        field.value_duration != null -> {
-          Type.DURATION
-        }
-        field.value_instant != null -> {
-          Type.INSTANT
-        }
-        else -> throw IllegalArgumentException(
-            "Can't determine field type since all value fields are null")
+        field.value_string != null -> Type.STRING
+        field.value_long != null -> Type.LONG
+        field.value_duration != null -> Type.DURATION
+        field.value_instant != null -> Type.INSTANT
+        // For cases where a DocumentData field in the template can be null, default to STRING
+        else -> Type.STRING
       }
       acc + mapOf(key to value)
     }
@@ -108,7 +100,8 @@ data class BarberSignature(
     /** BarberSignature is designated as naive since no type can be parsed from the code, so it is always String */
     fun DocumentTemplate.getNaiveSourceBarberSignature(mustacheFactory: MustacheFactory) = BarberSignature(
         fields.fold(mapOf()) { acc, field ->
-          acc + mustacheFactory.compile(StringReader(field.template!!), field.template).codes.fold(mapOf()) { acc2, code ->
+          acc + mustacheFactory.compile(StringReader(field.template!!), field.template).codes.fold(
+              mapOf()) { acc2, code ->
             if (code.name != null) {
               acc2 + mapOf(code.name to Type.STRING)
             } else {

--- a/barber/src/test/kotlin/app/cash/barber/models/BarberSignatureTest.kt
+++ b/barber/src/test/kotlin/app/cash/barber/models/BarberSignatureTest.kt
@@ -1,8 +1,8 @@
 package app.cash.barber.models
 
+import app.cash.barber.examples.EmptyDocumentData
 import app.cash.barber.examples.NestedLoginCode
 import app.cash.barber.examples.SenderReceipt
-import app.cash.barber.examples.EmptyDocumentData
 import app.cash.barber.examples.TransactionalEmailDocument
 import app.cash.barber.examples.TransactionalSmsDocument
 import app.cash.barber.examples.recipientReceiptSmsDocumentTemplateEN_US
@@ -306,6 +306,27 @@ class BarberSignatureTest {
         "amount" to Type.STRING,
         "cancelUrl" to Type.STRING,
         "deposit_expected_at" to Type.STRING,
+    ))
+    assertEquals(expected, actual)
+  }
+
+  @Test
+  fun `Default to String for null DocumentData Fields when Signature calculation is ambiguous`() {
+    val actual = DocumentData(
+        template_token = "T_123",
+        fields = listOf(
+            DocumentData.Field(
+                key = "alpha",
+                value_string = "non null"
+            ),
+            DocumentData.Field(
+                key = "bravo"
+            )
+        )
+    ).getBarberSignature()
+    val expected = BarberSignature(mapOf(
+        "alpha" to Type.STRING,
+        "bravo" to Type.STRING,
     ))
     assertEquals(expected, actual)
   }


### PR DESCRIPTION
There are legitimate cases where the DocumentData.Field will have a null value so to produce a valid Signature, we default to String type when the Signature is ambiguous from the null value.