### PR TITLE
Render null DocumentData field as empty string

### DIFF
--- a/barber/src/main/kotlin/app/cash/barber/RealBarber.kt
+++ b/barber/src/main/kotlin/app/cash/barber/RealBarber.kt
@@ -40,7 +40,9 @@ internal class RealBarber<D : Document>(
       // TODO add configurable formatters based on locale for non-string types
           ?: field.value_long?.toString()
           ?: field.value_duration?.toString()
-          ?: field.value_instant.toString())
+          ?: field.value_instant?.toString()
+          // If all values are null, render null as empty string
+          ?: "")
       acc + mapOf(field.key!! to value)
     }
 

--- a/barber/src/test/kotlin/app/cash/barber/BarberTest.kt
+++ b/barber/src/test/kotlin/app/cash/barber/BarberTest.kt
@@ -3,11 +3,14 @@ package app.cash.barber
 import app.cash.barber.examples.EncodingTestDocument
 import app.cash.barber.examples.InvestmentPurchase
 import app.cash.barber.examples.NestedLoginCode
+import app.cash.barber.examples.NullableSupportUrlReceipt
 import app.cash.barber.examples.RecipientReceipt
 import app.cash.barber.examples.TransactionalEmailDocument
 import app.cash.barber.examples.TransactionalSmsDocument
 import app.cash.barber.examples.investmentPurchaseEncodingDocumentTemplateEN_US
 import app.cash.barber.examples.mcDonaldsInvestmentPurchase
+import app.cash.barber.examples.nullSupportUrlReceipt
+import app.cash.barber.examples.nullableSupportUrlReceipt_EN_US
 import app.cash.barber.examples.recipientReceiptSmsDocumentTemplateEN_CA
 import app.cash.barber.examples.recipientReceiptSmsDocumentTemplateEN_GB
 import app.cash.barber.examples.recipientReceiptSmsDocumentTemplateEN_US
@@ -46,6 +49,20 @@ class BarberTest {
 
   @Test
   fun `Rendered spec is of specific Document type and allows field access`() {
+    val barber = BarbershopBuilder()
+        .installDocument<TransactionalSmsDocument>()
+        .installDocumentTemplate<NullableSupportUrlReceipt>(nullableSupportUrlReceipt_EN_US)
+        .build()
+
+    val spec = barber.getBarber<NullableSupportUrlReceipt, TransactionalSmsDocument>()
+        .render(nullSupportUrlReceipt, EN_US)
+
+    assertThat(spec.sms_body).isEqualTo(
+        "You got sent \$50.00.")
+  }
+
+  @Test
+  fun `Null DocumentData fields are rendered as empty string`() {
     val barber = BarbershopBuilder()
         .installDocument<TransactionalSmsDocument>()
         .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_US)

--- a/barber/src/test/kotlin/app/cash/barber/examples/NullableSupportUrlReceipt.kt
+++ b/barber/src/test/kotlin/app/cash/barber/examples/NullableSupportUrlReceipt.kt
@@ -1,0 +1,23 @@
+package app.cash.barber.examples
+
+import app.cash.barber.models.DocumentData
+import app.cash.barber.models.DocumentTemplate
+import app.cash.barber.models.Locale
+
+data class NullableSupportUrlReceipt(
+  val amount: String,
+  val hidableProblemUrl: String? = null
+) : DocumentData
+
+val nullableSupportUrlReceipt_EN_US = DocumentTemplate(
+    fields = mapOf(
+        "sms_body" to "You got sent {{ amount }}.{{ hidableProblemUrl }}"
+    ),
+    source = NullableSupportUrlReceipt::class,
+    targets = setOf(TransactionalSmsDocument::class),
+    locale = Locale.EN_US
+)
+
+val nullSupportUrlReceipt = NullableSupportUrlReceipt(
+    amount = "$50.00"
+)


### PR DESCRIPTION
To match existing and more intuitive functionality, a `null`
DocumentData field should be rendered as `""` not as `"null"`. New tests
broaden coverage to handle this previously untested but downstream used
functionality.
