### PR TITLE
Add Protos to Jar with Gradle Sourceset

### DIFF
--- a/barber/build.gradle
+++ b/barber/build.gradle
@@ -23,6 +23,12 @@ dependencies {
   testImplementation dep.kotlinTest
 }
 
+sourceSets {
+  main.kotlin {
+    srcDirs += "$buildDir/generated/source/wire/"
+  }
+}
+
 afterEvaluate { project ->
   project.tasks.dokka {
     outputDirectory = "$rootDir/docs/0.x"


### PR DESCRIPTION
This lets downstream consumers use the built protos from the Jar without having to compile from source.