### PR TITLE
Upgrade empty Barbershop Document/DocumentTemplate from Warning to Error

### DIFF
--- a/barber/src/main/kotlin/app/cash/barber/BarbershopBuilder.kt
+++ b/barber/src/main/kotlin/app/cash/barber/BarbershopBuilder.kt
@@ -142,13 +142,13 @@ class BarbershopBuilder : Barbershop.Builder {
 
     // Warn if Barber elements are not installed
     if (isEmpty()) {
-      warnings.add("""
+      errors.add("""
         |No DocumentData or DocumentTemplates installed
       """.trimMargin())
     }
     val installedDocumentsIsEmpty = installedDocuments.cellSet().isEmpty()
     if (installedDocumentsIsEmpty) {
-      warnings.add("""
+      errors.add("""
         |No Documents installed
       """.trimMargin())
     }

--- a/barber/src/test/kotlin/app/cash/barber/BarbershopBuilderTest.kt
+++ b/barber/src/test/kotlin/app/cash/barber/BarbershopBuilderTest.kt
@@ -165,6 +165,59 @@ class BarbershopBuilderTest {
   }
 
   @Test
+  fun `Install fails on no DocumentTemplate and DocumentData`() {
+    val exception = assertFailsWith<BarberException> {
+      BarbershopBuilder()
+          .installDocument<TransactionalEmailDocument>()
+          .build()
+    }
+
+    assertEquals(
+        """
+          |Errors
+          |1) No DocumentData or DocumentTemplates installed
+          |
+        """.trimMargin(),
+        exception.toString())
+  }
+
+  @Test
+  fun `Install warns on missing Document for an installed DocumentTemplate`() {
+    val exception = assertFailsWith<BarberException> {
+      BarbershopBuilder()
+          .installDocumentTemplate<RecipientReceipt>(investmentPurchaseShadowEncodingDocumentTemplateEN_US)
+          .installDocument<EncodingTestDocument>()
+          .setWarningsAsErrors()
+          .build()
+    }
+    assertEquals(
+        """
+          |Errors
+          |1) Attempted to install DocumentTemplate with a DocumentData not specified in the DocumentTemplate source
+          |DocumentTemplate.source: app.cash.barber.examples.InvestmentPurchase
+          |DocumentData: app.cash.barber.examples.RecipientReceipt
+          |
+        """.trimMargin(),
+        exception.toString())
+  }
+
+  @Test
+  fun `setWarningsAsErrors fails out early for install with no Documents`() {
+    val exception = assertFailsWith<BarberException> {
+      BarbershopBuilder()
+          .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_US)
+          .build()
+    }
+    assertEquals(
+        """
+          |Errors
+          |1) No Documents installed
+          |
+        """.trimMargin(),
+        exception.toString())
+  }
+
+  @Test
   fun `Fails on unused dangling installed Document`() {
     val exception = assertFailsWith<BarberException> {
       BarbershopBuilder()


### PR DESCRIPTION
In almost all cases other than the very beginnings of development, an
empty Barbershop is a bad thing so we should treat these as Errors, not
Warnings.
