### PR TITLE
Add new field to DocumentData to provide type hint for null

### DIFF
--- a/barber/src/main/kotlin/app/cash/barber/models/BarberSignature.kt
+++ b/barber/src/main/kotlin/app/cash/barber/models/BarberSignature.kt
@@ -63,6 +63,7 @@ data class BarberSignature(
         field.value_long != null -> Type.LONG
         field.value_duration != null -> Type.DURATION
         field.value_instant != null -> Type.INSTANT
+        field.value_null_type != null -> field.value_null_type
         // For cases where a DocumentData field in the template can be null, default to STRING
         else -> Type.STRING
       }

--- a/barber/src/main/kotlin/app/cash/barber/models/DocumentData.kt
+++ b/barber/src/main/kotlin/app/cash/barber/models/DocumentData.kt
@@ -4,8 +4,8 @@ import app.cash.barber.models.BarberSignature.Companion.getBarberSignature
 import app.cash.barber.models.TemplateToken.Companion.getTemplateToken
 import app.cash.protos.barber.api.BarberSignature.Type
 import app.cash.protos.barber.api.DocumentData
+import com.squareup.wire.Instant
 import java.time.Duration
-import java.time.Instant
 import kotlin.reflect.full.memberProperties
 
 /**
@@ -45,25 +45,37 @@ interface DocumentData {
   /** Provider interoperability with DocumentData proto */
   private fun toDocumentDataFields() = getBarberSignature().fields.map { (key, type) ->
     when (type) {
-      Type.STRING -> DocumentData.Field(
-          key = key,
-          value_string = getDocumentDataValue(key) as String?
-      )
-      Type.LONG -> DocumentData.Field(
-          key = key,
-          value_long = getDocumentDataValue(key) as Long?
-      )
-      Type.DURATION -> DocumentData.Field(
-          key = key,
-          value_duration = getDocumentDataValue(key) as Duration?
-      )
-      Type.INSTANT -> DocumentData.Field(
-          key = key,
-          value_instant = getDocumentDataValue(key) as Instant?
-      )
+      Type.STRING -> getDocumentDataValue(key)?.let {
+        DocumentData.Field(key = key,
+            value_string = it as String
+        )
+      } ?: getNullDocumentDataField(key, Type.STRING)
+      Type.LONG -> getDocumentDataValue(key)?.let {
+        DocumentData.Field(
+            key = key,
+            value_long = it as Long
+        )
+      } ?: getNullDocumentDataField(key, Type.LONG)
+      Type.DURATION -> getDocumentDataValue(key)?.let {
+        DocumentData.Field(
+            key = key,
+            value_duration = it as Duration
+        )
+      } ?: getNullDocumentDataField(key, Type.DURATION)
+      Type.INSTANT -> getDocumentDataValue(key)?.let {
+        DocumentData.Field(
+            key = key,
+            value_instant = it as Instant
+        )
+      } ?: getNullDocumentDataField(key, Type.INSTANT)
       Type.TYPE_DO_NOT_USE -> throw IllegalArgumentException("Can not parse TYPE_DO_NOT_USE")
     }
   }
+
+  private fun getNullDocumentDataField(key: String, type: Type) = DocumentData.Field(
+      key = key,
+      value_null_type = type
+  )
 
   /**
    * Lookup actual values for construction of proto using the dot separated full path from the

--- a/barber/src/main/proto/app/cash/barber/api/BarberApi.proto
+++ b/barber/src/main/proto/app/cash/barber/api/BarberApi.proto
@@ -29,6 +29,12 @@ message DocumentData {
       int64 value_long = 3;
       google.protobuf.Duration value_duration = 4;
       google.protobuf.Timestamp value_instant = 5;
+      /*
+       * For Kotlin DocumentData converted to Proto that have a null value, this field can provide
+       * a hint for the type which otherwise would be unknown since null would show up as all other
+       * value fields as null
+       */
+      BarberSignature.Type value_null_type = 6;
       // TODO add amount to support Money
     }
   }

--- a/barber/src/test/kotlin/app/cash/barber/examples/NullableCashBalanceReceipt.kt
+++ b/barber/src/test/kotlin/app/cash/barber/examples/NullableCashBalanceReceipt.kt
@@ -1,0 +1,8 @@
+package app.cash.barber.examples
+
+import app.cash.barber.models.DocumentData
+
+data class NullableCashBalanceReceipt(
+  val amount: Long,
+  val cashBalance: Long? = null
+): DocumentData


### PR DESCRIPTION
Up until now, Kotlin DocumentData converted to Proto would default to assuming String values when all `value_` fields are null, but we can do better. This new proto field provides the type hint in the cases of a DocumentData class with a nullable field set to null converted to proto.