### PR TITLE
Fix new version dropping Document target bug

### DIFF
--- a/barber/src/main/kotlin/app/cash/barber/Barber.kt
+++ b/barber/src/main/kotlin/app/cash/barber/Barber.kt
@@ -2,6 +2,7 @@ package app.cash.barber
 
 import app.cash.barber.models.Document
 import app.cash.barber.locale.Locale
+import app.cash.barber.models.VersionRange
 import app.cash.protos.barber.api.DocumentData
 
 /**
@@ -9,14 +10,21 @@ import app.cash.protos.barber.api.DocumentData
  */
 interface Barber<D : Document> {
   /**
+   * Set of the DocumentTemplate version ranges that are supported by this Barber
+   * This prevents the case of a DocumentTemplate changing which documents are targetted and a Barber
+   * not being able to support the change and blowing up at runtime
+   */
+  val supportedVersionRanges: Set<VersionRange>
+
+  /**
    * Render using a DocumentData Kotlin data class
    * @param version is optional additional parameter; latest compatible will be used if not provided
    */
-  fun <DD : app.cash.barber.models.DocumentData> render(documentData: DD, locale: Locale, version: Long = -1): D
+  fun <DD : app.cash.barber.models.DocumentData> render(documentData: DD, locale: Locale, version: Long? = null): D
 
   /**
    * Render using a DocumentData proto
    * @param version is optional additional parameter; latest compatible will be used if not provided
    */
-  fun render(documentData: DocumentData, locale: Locale, version: Long = -1): D
+  fun render(documentData: DocumentData, locale: Locale, version: Long? = null): D
 }

--- a/barber/src/main/kotlin/app/cash/barber/Barbershop.kt
+++ b/barber/src/main/kotlin/app/cash/barber/Barbershop.kt
@@ -19,24 +19,34 @@ interface Barbershop {
     documentClass: KClass<out D>
   ): Barber<D>
 
-  /** Get barber that can handle dynamic DocumentData proto */
+  /** Get barber that the latest (or optionally a specific [version]) DocumentData proto targets */
   fun <D : Document> getBarber(
     templateToken: TemplateToken,
     documentClass: KClass<out D>
   ): Barber<D>
 
-  /** Get Documents that a DocumentData Kotlin data class targets */
-  fun <DD : app.cash.barber.models.DocumentData> getTargetDocuments(documentDataClass: KClass<out DD>):
-      Set<KClass<out Document>>
+  /** Get Documents that the latest (or optionally a specific [version]) DocumentData Kotlin data class targets */
+  fun <DD : app.cash.barber.models.DocumentData> getTargetDocuments(
+    documentDataClass: KClass<out DD>,
+    version: Long? = null
+  ): Set<KClass<out Document>>
 
-  /** Get Documents that a templateToken targets */
-  fun getTargetDocuments(templateToken: TemplateToken): Set<KClass<out Document>>
+  /** Get Documents that the latest (or optionally a specific [version]) TemplateToken targets */
+  fun getTargetDocuments(
+    templateToken: TemplateToken,
+    version: Long? = null
+  ): Set<KClass<out Document>>
 
-  /** Get Documents that a templateToken targets */
-  fun getTargetDocuments(documentData: DocumentData): Set<KClass<out Document>>
+  /** Get Documents that the latest (or optionally a specific [version]) TemplateToken targets */
+  fun getTargetDocuments(
+    documentData: DocumentData,
+    version: Long? = null
+  ): Set<KClass<out Document>>
 
+  /** Get all Barbers installed and validated in the Barbershop */
   fun getAllBarbers(): Map<BarberKey, Barber<*>>
 
+  /** Get any Warnings raised from initial install and validation */
   fun getWarnings(): List<String>
 
   interface Builder {
@@ -86,5 +96,5 @@ inline fun <reified DD : app.cash.barber.models.DocumentData, reified D : Docume
 inline fun <reified D : Document> Barbershop.getBarber(templateToken: TemplateToken) = getBarber(
     templateToken, D::class)
 
-inline fun <reified DD : app.cash.barber.models.DocumentData> Barbershop.getTargetDocuments() = getTargetDocuments(
-    DD::class)
+inline fun <reified DD : app.cash.barber.models.DocumentData> Barbershop.getTargetDocuments(version: Long? = null) =
+    getTargetDocuments(documentDataClass = DD::class, version = version)

--- a/barber/src/main/kotlin/app/cash/barber/models/VersionRange.kt
+++ b/barber/src/main/kotlin/app/cash/barber/models/VersionRange.kt
@@ -1,0 +1,48 @@
+package app.cash.barber.models
+
+data class VersionRange(
+  val min: Long,
+  val max: Long
+) {
+  init {
+    check(min <= max) {
+      "Invalid VersionRange [min=$min] must be <= [max=$max]"
+    }
+  }
+
+  fun supports(version: Long) = version in min..max
+
+  companion object {
+    fun Set<Long>.asVersionRanges(): Set<VersionRange> {
+      val versionRanges = mutableSetOf<VersionRange>()
+      var localMin = -1L
+      var localMax = -1L
+      this.sorted().forEach { version ->
+        when {
+          localMin == -1L && localMax == -1L -> {
+            localMin = version
+            localMax = version
+          }
+          localMax == version - 1 -> localMax = version
+          localMax < version - 1 -> {
+            versionRanges.add(
+                VersionRange(localMin, localMax)
+            )
+            localMin = version
+            localMax = version
+          }
+        }
+      }
+      if (localMin != -1L && localMax != -1L) {
+        versionRanges.add(
+            VersionRange(localMin, localMax)
+        )
+      }
+      return versionRanges.toSet()
+    }
+
+    fun Set<VersionRange>.supports(version: Long) = any {
+      it.supports(version)
+    }
+  }
+}

--- a/barber/src/test/kotlin/app/cash/barber/BarberTest.kt
+++ b/barber/src/test/kotlin/app/cash/barber/BarberTest.kt
@@ -1,12 +1,16 @@
 package app.cash.barber
 
 import app.cash.barber.examples.EncodingTestDocument
+import app.cash.barber.examples.MultiVersionDocumentTargetChangeDocumentData
 import app.cash.barber.examples.InvestmentPurchase
 import app.cash.barber.examples.NestedLoginCode
 import app.cash.barber.examples.NullableSupportUrlReceipt
 import app.cash.barber.examples.RecipientReceipt
 import app.cash.barber.examples.TransactionalEmailDocument
 import app.cash.barber.examples.TransactionalSmsDocument
+import app.cash.barber.examples.multiVersionDocumentTargetChange
+import app.cash.barber.examples.multiVersionDocumentTarget_v4_email
+import app.cash.barber.examples.multiVersionDocumentTarget_v3_emailSms
 import app.cash.barber.examples.investmentPurchaseEncodingDocumentTemplateEN_US
 import app.cash.barber.examples.mcDonaldsInvestmentPurchase
 import app.cash.barber.examples.nullSupportUrlReceipt
@@ -15,16 +19,17 @@ import app.cash.barber.examples.recipientReceiptSmsDocumentTemplateEN_CA
 import app.cash.barber.examples.recipientReceiptSmsDocumentTemplateEN_GB
 import app.cash.barber.examples.recipientReceiptSmsDocumentTemplateEN_US
 import app.cash.barber.examples.sandy50Receipt
-import app.cash.barber.models.BarberSignature
-import app.cash.barber.models.DocumentTemplate
 import app.cash.barber.locale.Locale.Companion.EN_CA
 import app.cash.barber.locale.Locale.Companion.EN_GB
 import app.cash.barber.locale.Locale.Companion.EN_US
 import app.cash.barber.locale.Locale.Companion.ES_US
-import kotlin.test.assertEquals
+import app.cash.barber.models.BarberSignature
+import app.cash.barber.models.DocumentTemplate
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 
 /**
  * These our integration end to end tests
@@ -222,7 +227,8 @@ class BarberTest {
   fun `BarberField annotation configures Mustache render encoding per field`() {
     val barber = BarbershopBuilder()
         .installDocument<EncodingTestDocument>()
-        .installDocumentTemplate<InvestmentPurchase>(investmentPurchaseEncodingDocumentTemplateEN_US)
+        .installDocumentTemplate<InvestmentPurchase>(
+            investmentPurchaseEncodingDocumentTemplateEN_US)
         .build()
 
     val spec = barber.getBarber<InvestmentPurchase, EncodingTestDocument>()
@@ -242,9 +248,12 @@ class BarberTest {
   fun `Can install and render multiple versions`() {
     val key = recipientReceiptSmsDocumentTemplateEN_US.fields.keys.first()
     val field = recipientReceiptSmsDocumentTemplateEN_US.fields.values.first()
-    val v1 = recipientReceiptSmsDocumentTemplateEN_US.copy(fields = mapOf(key to "$field v1"), version = 1)
-    val v2 = recipientReceiptSmsDocumentTemplateEN_US.copy(fields = mapOf(key to "$field v2"), version = 2)
-    val v3 = recipientReceiptSmsDocumentTemplateEN_US.copy(fields = mapOf(key to "$field v3"), version = 3)
+    val v1 = recipientReceiptSmsDocumentTemplateEN_US.copy(fields = mapOf(key to "$field v1"),
+        version = 1)
+    val v2 = recipientReceiptSmsDocumentTemplateEN_US.copy(fields = mapOf(key to "$field v2"),
+        version = 2)
+    val v3 = recipientReceiptSmsDocumentTemplateEN_US.copy(fields = mapOf(key to "$field v3"),
+        version = 3)
 
     val barbershop = BarbershopBuilder()
         .installDocument<TransactionalSmsDocument>()
@@ -274,14 +283,19 @@ class BarberTest {
     val key = recipientReceiptSmsDocumentTemplateEN_US.fields.keys.first()
     val field = recipientReceiptSmsDocumentTemplateEN_US.fields.values.first()
 
-    val v1 = recipientReceiptSmsDocumentTemplateEN_US.copy(fields = mapOf(key to "New template with no fields v1"), version = 1)
+    val v1 = recipientReceiptSmsDocumentTemplateEN_US.copy(
+        fields = mapOf(key to "New template with no fields v1"), version = 1)
         .toProto()
         .copy(source_signature = "")
 
-    val v2 = recipientReceiptSmsDocumentTemplateEN_US.copy(fields = mapOf(key to "$field v2"), version = 2)
+    val v2 = recipientReceiptSmsDocumentTemplateEN_US.copy(fields = mapOf(key to "$field v2"),
+        version = 2)
 
-    val v3sourceSignature = BarberSignature(BarberSignature(v2.toProto().source_signature!!).fields + mapOf("new_variable_not_supported_yet" to app.cash.protos.barber.api.BarberSignature.Type.STRING))
-    val v3 = recipientReceiptSmsDocumentTemplateEN_US.copy(fields = mapOf(key to "$field {{ new_variable_not_supported_yet }} v3"), version = 3)
+    val v3sourceSignature = BarberSignature(
+        BarberSignature(v2.toProto().source_signature!!).fields + mapOf(
+            "new_variable_not_supported_yet" to app.cash.protos.barber.api.BarberSignature.Type.STRING))
+    val v3 = recipientReceiptSmsDocumentTemplateEN_US.copy(
+        fields = mapOf(key to "$field {{ new_variable_not_supported_yet }} v3"), version = 3)
         .toProto()
         .copy(source_signature = v3sourceSignature.signature)
 
@@ -317,14 +331,19 @@ class BarberTest {
     val key = recipientReceiptSmsDocumentTemplateEN_US.fields.keys.first()
     val field = recipientReceiptSmsDocumentTemplateEN_US.fields.values.first()
 
-    val v1 = recipientReceiptSmsDocumentTemplateEN_US.copy(fields = mapOf(key to "New template with no fields v1"), version = 1)
+    val v1 = recipientReceiptSmsDocumentTemplateEN_US.copy(
+        fields = mapOf(key to "New template with no fields v1"), version = 1)
         .toProto()
         .copy(source_signature = "")
 
-    val v2 = recipientReceiptSmsDocumentTemplateEN_US.copy(fields = mapOf(key to "$field v2"), version = 2)
+    val v2 = recipientReceiptSmsDocumentTemplateEN_US.copy(fields = mapOf(key to "$field v2"),
+        version = 2)
 
-    val v3sourceSignature = BarberSignature(BarberSignature(v2.toProto().source_signature!!).fields + mapOf("new_variable_not_supported_yet" to app.cash.protos.barber.api.BarberSignature.Type.STRING))
-    val v3 = recipientReceiptSmsDocumentTemplateEN_US.copy(fields = mapOf(key to "$field {{ new_variable_not_supported_yet }} v3"), version = 3)
+    val v3sourceSignature = BarberSignature(
+        BarberSignature(v2.toProto().source_signature!!).fields + mapOf(
+            "new_variable_not_supported_yet" to app.cash.protos.barber.api.BarberSignature.Type.STRING))
+    val v3 = recipientReceiptSmsDocumentTemplateEN_US.copy(
+        fields = mapOf(key to "$field {{ new_variable_not_supported_yet }} v3"), version = 3)
         .toProto()
         .copy(
             source_signature = v3sourceSignature.signature,
@@ -356,6 +375,66 @@ class BarberTest {
     assertEquals(
         "Sandy Winchester sent you \$50. It will be available at 2019-05-21T16:02:00Z. Cancel here: https://cash.app/cancel/123 v2",
         specMaxCompatible.sms_body)
+  }
+
+  @Test
+  fun `Barber render falls back on latest version it can support if document target removed in newer version`() {
+    val barbershop = BarbershopBuilder()
+        .installDocument<TransactionalEmailDocument>()
+        .installDocument<EncodingTestDocument>()
+        .installDocument<TransactionalSmsDocument>()
+        .installDocumentTemplate<MultiVersionDocumentTargetChangeDocumentData>(multiVersionDocumentTarget_v3_emailSms)
+        .installDocumentTemplate<MultiVersionDocumentTargetChangeDocumentData>(multiVersionDocumentTarget_v4_email)
+        .build()
+
+    val targetDocumentsVersion1 = barbershop.getTargetDocuments<MultiVersionDocumentTargetChangeDocumentData>(
+        multiVersionDocumentTarget_v3_emailSms.version)
+    assertEquals(setOf(TransactionalEmailDocument::class, TransactionalSmsDocument::class),
+        targetDocumentsVersion1)
+    val targetDocumentsVersion2 = barbershop.getTargetDocuments<MultiVersionDocumentTargetChangeDocumentData>(
+        multiVersionDocumentTarget_v4_email.version)
+    assertEquals(setOf(TransactionalEmailDocument::class), targetDocumentsVersion2)
+    val targetDocumentsDefaultVersion = barbershop.getTargetDocuments<MultiVersionDocumentTargetChangeDocumentData>()
+    assertEquals(setOf(TransactionalEmailDocument::class), targetDocumentsDefaultVersion)
+
+    // Check that these can all render successfully without throwing BarberException
+    val emailRendersWithDefaultVersion =
+        barbershop.getBarber<MultiVersionDocumentTargetChangeDocumentData, TransactionalEmailDocument>()
+            .render(multiVersionDocumentTargetChange, EN_US)
+    assertEquals("v4", emailRendersWithDefaultVersion.subject)
+    val emailRendersWithVersion3 =
+        barbershop.getBarber<MultiVersionDocumentTargetChangeDocumentData, TransactionalEmailDocument>()
+            .render(multiVersionDocumentTargetChange, EN_US, 3)
+    assertEquals("v3", emailRendersWithVersion3.subject)
+    val emailRendersWithVersion4 =
+        barbershop.getBarber<MultiVersionDocumentTargetChangeDocumentData, TransactionalEmailDocument>()
+            .render(multiVersionDocumentTargetChange, EN_US, 4)
+    assertEquals("v4", emailRendersWithVersion4.subject)
+
+    val smsRendersWithDefaultVersion =
+        barbershop.getBarber<MultiVersionDocumentTargetChangeDocumentData, TransactionalSmsDocument>()
+            .render(multiVersionDocumentTargetChange, EN_US)
+    assertEquals("v3", smsRendersWithDefaultVersion.sms_body)
+    val smsRendersWithVersion3 =
+        barbershop.getBarber<MultiVersionDocumentTargetChangeDocumentData, TransactionalSmsDocument>()
+            .render(multiVersionDocumentTargetChange, EN_US, 3)
+    assertEquals("v3", smsRendersWithVersion3.sms_body)
+    // Falls back to v3 since v4 doesn't support SMS
+    val smsRendersWithVersion4 =
+        barbershop.getBarber<MultiVersionDocumentTargetChangeDocumentData, TransactionalSmsDocument>()
+            .render(multiVersionDocumentTargetChange, EN_US, 4)
+    assertEquals("v3", smsRendersWithVersion4.sms_body)
+
+    // Blows up when trying to render template that doesn't have Document as Target
+    val exception = assertFailsWith<BarberException> {
+      barbershop.getBarber<MultiVersionDocumentTargetChangeDocumentData, EncodingTestDocument>()
+    }
+    assertEquals("""
+      |Errors
+      |1) Failed to get Barber<app.cash.barber.examples.EncodingTestDocument>(templateToken=multiVersionDocumentTargetChange)
+      |Document [class app.cash.barber.examples.EncodingTestDocument] is not installed in Barbershop
+      |
+    """.trimMargin(), exception.toString())
   }
 
   @Disabled @Test

--- a/barber/src/test/kotlin/app/cash/barber/BarbershopTest.kt
+++ b/barber/src/test/kotlin/app/cash/barber/BarbershopTest.kt
@@ -1,9 +1,12 @@
 package app.cash.barber
 
+import app.cash.barber.examples.MultiVersionDocumentTargetChangeDocumentData
 import app.cash.barber.examples.RecipientReceipt
 import app.cash.barber.examples.SenderReceipt
 import app.cash.barber.examples.TransactionalEmailDocument
 import app.cash.barber.examples.TransactionalSmsDocument
+import app.cash.barber.examples.multiVersionDocumentTarget_v4_email
+import app.cash.barber.examples.multiVersionDocumentTarget_v3_emailSms
 import app.cash.barber.examples.recipientReceiptSmsDocumentTemplateEN_CA
 import app.cash.barber.examples.recipientReceiptSmsDocumentTemplateEN_GB
 import app.cash.barber.examples.recipientReceiptSmsDocumentTemplateEN_US
@@ -115,5 +118,23 @@ class BarbershopTest {
         .build()
     val supportedDocuments = barbershop.getTargetDocuments<SenderReceipt>()
     assertThat(supportedDocuments).isEmpty()
+  }
+
+  @Test
+  fun `getTargetDocuments returns version aware targets`() {
+    val barbershop = BarbershopBuilder()
+        .installDocument<TransactionalEmailDocument>()
+        .installDocument<TransactionalSmsDocument>()
+        .installDocumentTemplate<MultiVersionDocumentTargetChangeDocumentData>(multiVersionDocumentTarget_v3_emailSms)
+        .installDocumentTemplate<MultiVersionDocumentTargetChangeDocumentData>(multiVersionDocumentTarget_v4_email)
+        .build()
+
+    val targetDocumentsLatestVersion = barbershop.getTargetDocuments<MultiVersionDocumentTargetChangeDocumentData>()
+    assertEquals(setOf(TransactionalEmailDocument::class), targetDocumentsLatestVersion)
+
+    val targetDocumentsVersion1 = barbershop.getTargetDocuments<MultiVersionDocumentTargetChangeDocumentData>(multiVersionDocumentTarget_v3_emailSms.version)
+    assertEquals(setOf(TransactionalEmailDocument::class, TransactionalSmsDocument::class), targetDocumentsVersion1)
+    val targetDocumentsVersion2 = barbershop.getTargetDocuments<MultiVersionDocumentTargetChangeDocumentData>(multiVersionDocumentTarget_v4_email.version)
+    assertEquals(setOf(TransactionalEmailDocument::class), targetDocumentsVersion2)
   }
 }

--- a/barber/src/test/kotlin/app/cash/barber/examples/MultiVersionDocumentTargetChangeDocumentData.kt
+++ b/barber/src/test/kotlin/app/cash/barber/examples/MultiVersionDocumentTargetChangeDocumentData.kt
@@ -1,0 +1,43 @@
+package app.cash.barber.examples
+
+import app.cash.barber.locale.Locale
+import app.cash.barber.models.DocumentData
+import app.cash.barber.models.DocumentTemplate
+import java.time.Instant
+
+class MultiVersionDocumentTargetChangeDocumentData : DocumentData
+
+val multiVersionDocumentTarget_v3_emailSms = DocumentTemplate(
+    fields = mapOf(
+        "sms_body" to "v3",
+        "subject" to "v3",
+        "headline" to "v3",
+        "short_description" to "v3",
+        "primary_button" to "v3",
+        "primary_button_url" to "v3",
+        "secondary_button" to "v3",
+        "secondary_button_url" to "v3",
+    ),
+    locale = Locale.EN_US,
+    source = MultiVersionDocumentTargetChangeDocumentData::class,
+    targets = setOf(TransactionalEmailDocument::class, TransactionalSmsDocument::class),
+    version = 3L
+)
+
+val multiVersionDocumentTarget_v4_email = DocumentTemplate(
+    fields = mapOf(
+        "subject" to "v4", 
+        "headline" to "v4", 
+        "short_description" to "v4", 
+        "primary_button" to "v4", 
+        "primary_button_url" to "v4",
+        "secondary_button" to "v4", 
+        "secondary_button_url" to "v4", 
+    ),
+    locale = Locale.EN_US,
+    source = MultiVersionDocumentTargetChangeDocumentData::class,
+    targets = setOf(TransactionalEmailDocument::class),
+    version = 4L
+)
+
+val multiVersionDocumentTargetChange = MultiVersionDocumentTargetChangeDocumentData()

--- a/barber/src/test/kotlin/app/cash/barber/models/VersionRangeTest.kt
+++ b/barber/src/test/kotlin/app/cash/barber/models/VersionRangeTest.kt
@@ -1,0 +1,86 @@
+package app.cash.barber.models
+
+import app.cash.barber.models.VersionRange.Companion.supports
+import app.cash.barber.models.VersionRange.Companion.asVersionRanges
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class VersionRangeTest {
+  @Test
+  fun `happy path`() {
+    val versions1 = setOf(1L, 2L, 3L, 4L, 8L, 10L, 11L, 12L, 16L, 17L)
+    val expected1 = setOf(
+        VersionRange(1L, 4L),
+        VersionRange(8L, 8L),
+        VersionRange(10L, 12L),
+        VersionRange(16L, 17L),
+    )
+    val actual1 = versions1.asVersionRanges()
+    assertEquals(expected1, actual1)
+
+    val versions2 = setOf(1L, 2L, 3L)
+    val expected2 = setOf(
+        VersionRange(1L, 3L),
+    )
+    val actual2 = versions2.asVersionRanges()
+    assertEquals(expected2, actual2)
+
+    val versions3 = setOf(1L)
+    val expected3 = setOf(
+        VersionRange(1L, 1L),
+    )
+    val actual3 = versions3.asVersionRanges()
+    assertEquals(expected3, actual3)
+
+    val versions4 = setOf(1L, 4L, 7L)
+    val expected4 = setOf(
+        VersionRange(1L, 1L),
+        VersionRange(4L, 4L),
+        VersionRange(7L, 7L),
+    )
+    val actual4 = versions4.asVersionRanges()
+    assertEquals(expected4, actual4)
+  }
+
+  @Test
+  fun `supports happy path`() {
+    val ranges1 = setOf(
+        VersionRange(1L, 4L),
+        VersionRange(8L, 8L),
+        VersionRange(10L, 12L),
+        VersionRange(16L, 17L),
+    )
+    assertTrue(ranges1.supports(1L))
+    assertTrue(ranges1.supports(3L))
+    assertTrue(ranges1.supports(4L))
+    assertTrue(ranges1.supports(8L))
+    assertTrue(ranges1.supports(10L))
+    assertTrue(ranges1.supports(12L))
+    assertTrue(ranges1.supports(16L))
+    assertTrue(ranges1.supports(17L))
+    assertFalse(ranges1.supports(5L))
+    assertFalse(ranges1.supports(7L))
+    assertFalse(ranges1.supports(9L))
+    assertFalse(ranges1.supports(13L))
+    assertFalse(ranges1.supports(15L))
+    assertFalse(ranges1.supports(18L))
+    assertFalse(ranges1.supports(20L))
+
+    val ranges2 = setOf(
+        VersionRange(1L, 1L),
+    )
+    assertTrue(ranges2.supports(1L))
+    assertFalse(ranges2.supports(2L))
+  }
+
+  @Test
+  fun `min gt max`() {
+    val exception = assertFailsWith<IllegalStateException> {
+      VersionRange(3L, 1L)
+    }
+    assertEquals("java.lang.IllegalStateException: Invalid VersionRange [min=3] must be <= [max=1]", exception.toString())
+  }
+}


### PR DESCRIPTION
This bug caused a SEV in two ways
1) getTargetDocuments returned an aggregate across all versions so if
   the target Documents changed in a newer version (& getTargetDocuments
   API is used to gate renders in calling service) then the render call
   fails explosively in `RealBarber`
2) Barber.render didn't fall back to template versions it could render
   assuming that all template versions supported the same target
   Document set

This PR addresses both failures with tests to verify and enforce correct
functionality moving forward
