### PR TITLE
Fix CompiledDocumentTemplate to gracefully allow empty target_signatures

### DIFF
--- a/barber/src/main/kotlin/app/cash/barber/models/CompiledDocumentTemplate.kt
+++ b/barber/src/main/kotlin/app/cash/barber/models/CompiledDocumentTemplate.kt
@@ -54,15 +54,19 @@ data class CompiledDocumentTemplate(
       val explicitSourceSignature = BarberSignature(source_signature!!)
 
       // Common projections for the following validation
-      val targetKParameterDocumentMap = target_signatures.map { signature ->
-        installedDocuments.row(BarberSignature(signature)).values.map {
-          it.document to it.kParameter
-        }
-      }.reduce { acc, list -> acc + list }
+      val targetKParameterDocumentMap = if (target_signatures.isEmpty()) {
+        emptyMap()
+      } else {
+        target_signatures.map { signature ->
+          installedDocuments.row(BarberSignature(signature)).values.map {
+            it.document to it.kParameter
+          }
+        }.reduce { acc, list -> acc + list }
           .toSet()
           .associate { (document, kParameter) ->
             kParameter to document
           }
+      }
       val targetFieldNames = targetKParameterDocumentMap.keys.map {
         it.name
       }

--- a/barber/src/test/kotlin/app/cash/barber/BarbershopBuilderTest.kt
+++ b/barber/src/test/kotlin/app/cash/barber/BarbershopBuilderTest.kt
@@ -14,6 +14,7 @@ import app.cash.barber.examples.investmentPurchaseEncodingDocumentTemplateEN_US
 import app.cash.barber.examples.investmentPurchaseShadowEncodingDocumentTemplateEN_US
 import app.cash.barber.examples.mcDonaldsInvestmentPurchase
 import app.cash.barber.examples.noParametersDocumentTemplate
+import app.cash.barber.examples.noTargetsDocumentTemplate
 import app.cash.barber.examples.plaintextDocumentTemplateEN_US
 import app.cash.barber.examples.recipientReceiptSmsDocumentTemplateEN_CA
 import app.cash.barber.examples.recipientReceiptSmsDocumentTemplateEN_GB
@@ -69,6 +70,14 @@ class BarbershopBuilderTest {
         .installDocument<TransactionalEmailDocument>()
         .installDocument<TransactionalSmsDocument>()
         .build()
+  }
+
+  @Test
+  fun `Install works when DocumentTemplate has no targets`() {
+    BarbershopBuilder()
+      .installDocument<TransactionalSmsDocument>()
+      .installDocumentTemplate<EmptyDocumentData>(noTargetsDocumentTemplate)
+      .build()
   }
 
   @Test

--- a/barber/src/test/kotlin/app/cash/barber/examples/EmptyDocumentData.kt
+++ b/barber/src/test/kotlin/app/cash/barber/examples/EmptyDocumentData.kt
@@ -1,0 +1,5 @@
+package app.cash.barber.examples
+
+import app.cash.barber.models.DocumentData
+
+class EmptyDocumentData : DocumentData

--- a/barber/src/test/kotlin/app/cash/barber/examples/NoTargets.kt
+++ b/barber/src/test/kotlin/app/cash/barber/examples/NoTargets.kt
@@ -1,14 +1,11 @@
 package app.cash.barber.examples
 
 import app.cash.barber.locale.Locale
-import app.cash.barber.models.Document
 import app.cash.barber.models.DocumentTemplate
 
-class NoParametersDocument : Document
-
-val noParametersDocumentTemplate = DocumentTemplate(
+val noTargetsDocumentTemplate = DocumentTemplate(
     fields = mapOf(),
     source = EmptyDocumentData::class,
-    targets = setOf(NoParametersDocument::class),
+    targets = emptySet(),
     locale = Locale.EN_US
 )


### PR DESCRIPTION
Fixes exceptions when target_signatures is empty on DocumentTemplate:
```
Caused by: java.lang.UnsupportedOperationException: Empty collection can't be reduced.
```