### PR TITLE
Update shortname for consistency

### DIFF
--- a/barber/build.gradle.kts
+++ b/barber/build.gradle.kts
@@ -10,7 +10,7 @@ dependencies {
   api(project(":barber-protos"))
 
   implementation(Dependencies.guava)
-  implementation(Dependencies.kotlinStdLib)
+  implementation(Dependencies.kotlinStdLibJdk8)
   implementation(Dependencies.kotlinReflection)
   implementation(Dependencies.moshiCore)
   implementation(Dependencies.moshiKotlin)

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -14,7 +14,7 @@ object Dependencies {
   val kotlinGradlePlugin = "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.71"
   val kotlinReflection = "org.jetbrains.kotlin:kotlin-reflect:1.3.71"
   val kotlinScriptRuntime = "org.jetbrains.kotlin:kotlin-script-runtime:1.3.71"
-  val kotlinStdLib = "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.71"
+  val kotlinStdLibJdk8 = "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.71"
   val kotlinTest = "org.jetbrains.kotlin:kotlin-test:1.3.71"
   val ktlintVersion = "0.34.2"
   val loggingApi = "io.github.microutils:kotlin-logging:1.7.9"


### PR DESCRIPTION
The shortname used for org.jetbrains.kotlin:kotlin-stdlib-jdk8 in
other repositories is `kotlinStdLibJdk8`. For the sake of some internal
tooling it would be better if this was consistent in barber as well.