### PR TITLE
Add Barber Field Encoding for HttpUrl

### DIFF
--- a/barber/build.gradle.kts
+++ b/barber/build.gradle.kts
@@ -15,6 +15,7 @@ dependencies {
   implementation(Dependencies.moshiCore)
   implementation(Dependencies.moshiKotlin)
   implementation(Dependencies.okio)
+  implementation(Dependencies.okHttp)
   implementation(Dependencies.mustacheCompiler)
   implementation(Dependencies.wireMoshiAdapter)
   implementation(Dependencies.wireRuntime)

--- a/barber/src/main/kotlin/app/cash/barber/BarberHttpUrlMustacheFactory.kt
+++ b/barber/src/main/kotlin/app/cash/barber/BarberHttpUrlMustacheFactory.kt
@@ -1,17 +1,18 @@
 package app.cash.barber
 
-import app.cash.barber.models.BarberFieldEncoding.STRING_PLAINTEXT
+import app.cash.barber.models.BarberFieldEncoding.STRING_HTTPURL
 import com.github.mustachejava.DefaultMustacheFactory
 import com.github.mustachejava.MustacheException
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import java.io.Writer
 
 /**
- * Mustache Factory that handles [STRING_PLAINTEXT] fields and doesn't apply the HTML escaping
+ * Mustache Factory that handles [STRING_HTTPURL] fields and doesn't apply the HTML escaping
  *  present in [DefaultMustacheFactory]
  */
-class BarberPlaintextMustacheFactory : DefaultMustacheFactory() {
+class BarberHttpUrlMustacheFactory : DefaultMustacheFactory() {
   override fun encode(value: String?, writer: Writer?) {
-    value?.let { writer?.write(it) }
+    value?.let { writer?.write(it.toHttpUrl().toString()) }
       ?: throw MustacheException("Null Writer. Failed to encode value: $value")
   }
 }

--- a/barber/src/main/kotlin/app/cash/barber/BarberMustacheFactoryProvider.kt
+++ b/barber/src/main/kotlin/app/cash/barber/BarberMustacheFactoryProvider.kt
@@ -12,8 +12,10 @@ class BarberMustacheFactoryProvider(
 ) {
   private val defaultMustacheFactory = DefaultMustacheFactory()
   private val barberPlaintextMustacheFactory = BarberPlaintextMustacheFactory()
+  private val barberHttpUrlMustacheFactory = BarberHttpUrlMustacheFactory()
   fun get(encoding: BarberFieldEncoding? = null) = when (encoding ?: defaultBarberFieldEncoding) {
     BarberFieldEncoding.STRING_PLAINTEXT -> barberPlaintextMustacheFactory
     BarberFieldEncoding.STRING_HTML -> defaultMustacheFactory
+    BarberFieldEncoding.STRING_HTTPURL -> barberHttpUrlMustacheFactory
   }
 }

--- a/barber/src/main/kotlin/app/cash/barber/models/BarberFieldEncoding.kt
+++ b/barber/src/main/kotlin/app/cash/barber/models/BarberFieldEncoding.kt
@@ -4,5 +4,5 @@ package app.cash.barber.models
  * Used in [BarberField] annotation on Document fields to specify the encoding to render using.
  */
 enum class BarberFieldEncoding {
-  STRING_HTML, STRING_PLAINTEXT
+  STRING_HTML, STRING_PLAINTEXT, STRING_HTTPURL
 }

--- a/barber/src/test/kotlin/app/cash/barber/BarberTest.kt
+++ b/barber/src/test/kotlin/app/cash/barber/BarberTest.kt
@@ -1,18 +1,19 @@
 package app.cash.barber
 
 import app.cash.barber.examples.EncodingTestDocument
-import app.cash.barber.examples.MultiVersionDocumentTargetChangeDocumentData
 import app.cash.barber.examples.InvestmentPurchase
+import app.cash.barber.examples.MultiVersionDocumentTargetChangeDocumentData
 import app.cash.barber.examples.NestedLoginCode
 import app.cash.barber.examples.NullableSupportUrlReceipt
 import app.cash.barber.examples.RecipientReceipt
 import app.cash.barber.examples.TransactionalEmailDocument
 import app.cash.barber.examples.TransactionalSmsDocument
-import app.cash.barber.examples.multiVersionDocumentTargetChange
-import app.cash.barber.examples.multiVersionDocumentTarget_v4_email
-import app.cash.barber.examples.multiVersionDocumentTarget_v3_emailSms
 import app.cash.barber.examples.investmentPurchaseEncodingDocumentTemplateEN_US
 import app.cash.barber.examples.mcDonaldsInvestmentPurchase
+import app.cash.barber.examples.mcDonaldsInvestmentPurchaseUrl
+import app.cash.barber.examples.multiVersionDocumentTargetChange
+import app.cash.barber.examples.multiVersionDocumentTarget_v3_emailSms
+import app.cash.barber.examples.multiVersionDocumentTarget_v4_email
 import app.cash.barber.examples.nullSupportUrlReceipt
 import app.cash.barber.examples.nullableSupportUrlReceipt_EN_US
 import app.cash.barber.examples.recipientReceiptSmsDocumentTemplateEN_CA
@@ -30,7 +31,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
-import org.junit.jupiter.api.assertThrows
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 
@@ -41,17 +41,17 @@ class BarberTest {
   @Test
   fun `Render an SMS`() {
     val barber = BarbershopBuilder()
-        .installDocument<TransactionalSmsDocument>()
-        .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_US)
-        .build()
+      .installDocument<TransactionalSmsDocument>()
+      .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_US)
+      .build()
 
     val spec = barber.getBarber<RecipientReceipt, TransactionalSmsDocument>()
-        .render(sandy50Receipt, EN_US)
+      .render(sandy50Receipt, EN_US)
 
     assertThat(spec).isEqualTo(
-        TransactionalSmsDocument(
-            sms_body = "Sandy Winchester sent you \$50. It will be available at 2019-05-21T16:02:00Z. Cancel here: https://cash.app/cancel/123"
-        )
+      TransactionalSmsDocument(
+        sms_body = "Sandy Winchester sent you \$50. It will be available at 2019-05-21T16:02:00Z. Cancel here: https://cash.app/cancel/123"
+      )
     )
   }
 
@@ -59,10 +59,12 @@ class BarberTest {
   fun `Can install template with null field values`() {
     val documentTemplate = recipientReceiptSmsDocumentTemplateEN_US.toProto()
     val documentTemplateWithInvalidField = documentTemplate.copy(
-      fields = documentTemplate.fields.map { app.cash.protos.barber.api.DocumentTemplate.Field(
-        key = it.key,
-        template = null
-      ) }
+      fields = documentTemplate.fields.map {
+        app.cash.protos.barber.api.DocumentTemplate.Field(
+          key = it.key,
+          template = null
+        )
+      }
         // Sort this so that the exception message is ordered for easier asserting
         .sortedBy { it.key }
     )
@@ -78,12 +80,12 @@ class BarberTest {
   @Test
   fun `Rendered spec is of specific Document type and allows field access`() {
     val barber = BarbershopBuilder()
-        .installDocument<TransactionalSmsDocument>()
-        .installDocumentTemplate<NullableSupportUrlReceipt>(nullableSupportUrlReceipt_EN_US)
-        .build()
+      .installDocument<TransactionalSmsDocument>()
+      .installDocumentTemplate<NullableSupportUrlReceipt>(nullableSupportUrlReceipt_EN_US)
+      .build()
 
     val spec = barber.getBarber<NullableSupportUrlReceipt, TransactionalSmsDocument>()
-        .render(nullSupportUrlReceipt, EN_US)
+      .render(nullSupportUrlReceipt, EN_US)
 
     assertThat(spec.sms_body).isEqualTo("You got sent \$50.00.")
   }
@@ -91,179 +93,185 @@ class BarberTest {
   @Test
   fun `Null DocumentData fields are rendered as empty string`() {
     val barber = BarbershopBuilder()
-        .installDocument<TransactionalSmsDocument>()
-        .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_US)
-        .build()
+      .installDocument<TransactionalSmsDocument>()
+      .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_US)
+      .build()
 
     val spec = barber.getBarber<RecipientReceipt, TransactionalSmsDocument>()
-        .render(sandy50Receipt, EN_US)
+      .render(sandy50Receipt, EN_US)
 
     // Spec matches
     assertThat(spec).isEqualTo(
-        TransactionalSmsDocument(
-            sms_body = "Sandy Winchester sent you \$50. It will be available at 2019-05-21T16:02:00Z. Cancel here: https://cash.app/cancel/123"
-        )
+      TransactionalSmsDocument(
+        sms_body = "Sandy Winchester sent you \$50. It will be available at 2019-05-21T16:02:00Z. Cancel here: https://cash.app/cancel/123"
+      )
     )
 
     // Returned rendered spec is type safely accessible
     assertThat(spec.sms_body).isEqualTo(
-        "Sandy Winchester sent you \$50. It will be available at 2019-05-21T16:02:00Z. Cancel here: https://cash.app/cancel/123")
+      "Sandy Winchester sent you \$50. It will be available at 2019-05-21T16:02:00Z. Cancel here: https://cash.app/cancel/123"
+    )
   }
 
   @Test
   fun `Render an email`() {
     val recipientReceiptDocumentData = DocumentTemplate(
-        fields = mapOf(
-            "subject" to "{{sender}} sent you {{amount}}",
-            "headline" to "You received {{amount}}",
-            "short_description" to "You’ve received a payment from {{sender}}! The money will be in your bank account " +
-                "{{deposit_expected_at}}.",
-            "primary_button" to "Cancel this payment",
-            "primary_button_url" to "{{cancelUrl}}"
-        ),
-        source = RecipientReceipt::class,
-        targets = setOf(TransactionalEmailDocument::class),
-        locale = EN_US
+      fields = mapOf(
+        "subject" to "{{sender}} sent you {{amount}}",
+        "headline" to "You received {{amount}}",
+        "short_description" to "You’ve received a payment from {{sender}}! The money will be in your bank account " +
+          "{{deposit_expected_at}}.",
+        "primary_button" to "Cancel this payment",
+        "primary_button_url" to "{{cancelUrl}}"
+      ),
+      source = RecipientReceipt::class,
+      targets = setOf(TransactionalEmailDocument::class),
+      locale = EN_US
     )
 
     val barber = BarbershopBuilder()
-        .installDocument<TransactionalEmailDocument>()
-        .installDocumentTemplate<RecipientReceipt>(recipientReceiptDocumentData)
-        .build()
+      .installDocument<TransactionalEmailDocument>()
+      .installDocumentTemplate<RecipientReceipt>(recipientReceiptDocumentData)
+      .build()
 
     val spec = barber.getBarber<RecipientReceipt, TransactionalEmailDocument>()
-        .render(sandy50Receipt, EN_US)
+      .render(sandy50Receipt, EN_US)
 
     assertThat(spec).isEqualTo(
-        TransactionalEmailDocument(
-            subject = "Sandy Winchester sent you $50",
-            headline = "You received $50",
-            short_description = "You’ve received a payment from Sandy Winchester! The money will be in your bank account 2019-05-21T16:02:00Z.",
-            primary_button = "Cancel this payment",
-            primary_button_url = "https://cash.app/cancel/123",
-            secondary_button = null,
-            secondary_button_url = null
-        )
+      TransactionalEmailDocument(
+        subject = "Sandy Winchester sent you $50",
+        headline = "You received $50",
+        short_description = "You’ve received a payment from Sandy Winchester! The money will be in your bank account 2019-05-21T16:02:00Z.",
+        primary_button = "Cancel this payment",
+        primary_button_url = "https://cash.app/cancel/123",
+        secondary_button = null,
+        secondary_button_url = null
+      )
     )
   }
 
   @Test
   fun `Render an email and sms with nested data`() {
     val nestedLoginCode = NestedLoginCode(
-        code = "123-456",
-        button = NestedLoginCode.EmailButton(
-            color = "#B3B3B3",
-            text = "Login",
-            link = "https://cash.app/login",
-            size = "regular"
-        )
+      code = "123-456",
+      button = NestedLoginCode.EmailButton(
+        color = "#B3B3B3",
+        text = "Login",
+        link = "https://cash.app/login",
+        size = "regular"
+      )
     )
 
     val nestedLoginCodeEN_US = DocumentTemplate(
-        fields = mapOf(
-            "subject" to "Your login code is {{code}}",
-            "headline" to "Your login code is {{code}}",
-            "short_description" to "Your login code is {{code}}",
-            "primary_button" to "<Button color=\"{{button.color}}\" size=\"{{button.size}}\">{{button.text}}</Button>",
-            "primary_button_url" to "{{button.link}}",
-            "sms_body" to "Your login code is {{code}}. Go to {{button.link}} to login."
-        ),
-        source = NestedLoginCode::class,
-        targets = setOf(TransactionalEmailDocument::class, TransactionalSmsDocument::class),
-        locale = EN_US
+      fields = mapOf(
+        "subject" to "Your login code is {{code}}",
+        "headline" to "Your login code is {{code}}",
+        "short_description" to "Your login code is {{code}}",
+        "primary_button" to "<Button color=\"{{button.color}}\" size=\"{{button.size}}\">{{button.text}}</Button>",
+        "primary_button_url" to "{{button.link}}",
+        "sms_body" to "Your login code is {{code}}. Go to {{button.link}} to login."
+      ),
+      source = NestedLoginCode::class,
+      targets = setOf(TransactionalEmailDocument::class, TransactionalSmsDocument::class),
+      locale = EN_US
     )
 
     val barber = BarbershopBuilder()
-        .installDocument<TransactionalEmailDocument>()
-        .installDocument<TransactionalSmsDocument>()
-        .installDocumentTemplate<NestedLoginCode>(nestedLoginCodeEN_US)
-        .build()
+      .installDocument<TransactionalEmailDocument>()
+      .installDocument<TransactionalSmsDocument>()
+      .installDocumentTemplate<NestedLoginCode>(nestedLoginCodeEN_US)
+      .build()
 
     val emailSpec = barber.getBarber<NestedLoginCode, TransactionalEmailDocument>()
-        .render(nestedLoginCode, EN_US)
+      .render(nestedLoginCode, EN_US)
 
     assertThat(emailSpec).isEqualTo(
-        TransactionalEmailDocument(
-            subject = "Your login code is 123-456",
-            headline = "Your login code is 123-456",
-            short_description = "Your login code is 123-456",
-            primary_button = "<Button color=\"#B3B3B3\" size=\"regular\">Login</Button>",
-            primary_button_url = "https://cash.app/login",
-            secondary_button = null,
-            secondary_button_url = null
-        )
+      TransactionalEmailDocument(
+        subject = "Your login code is 123-456",
+        headline = "Your login code is 123-456",
+        short_description = "Your login code is 123-456",
+        primary_button = "<Button color=\"#B3B3B3\" size=\"regular\">Login</Button>",
+        primary_button_url = "https://cash.app/login",
+        secondary_button = null,
+        secondary_button_url = null
+      )
     )
 
     val smsSpec = barber.getBarber<NestedLoginCode, TransactionalSmsDocument>()
-        .render(nestedLoginCode, EN_US)
+      .render(nestedLoginCode, EN_US)
 
     assertThat(smsSpec).isEqualTo(
-        TransactionalSmsDocument(
-            sms_body = "Your login code is 123-456. Go to https://cash.app/login to login."
-        )
+      TransactionalSmsDocument(
+        sms_body = "Your login code is 123-456. Go to https://cash.app/login to login."
+      )
     )
   }
 
   @Test
   fun `Can install and render multiple locales`() {
     val barbershop = BarbershopBuilder()
-        .installDocument<TransactionalSmsDocument>()
-        .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_US)
-        .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_CA)
-        .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_GB)
-        .build()
+      .installDocument<TransactionalSmsDocument>()
+      .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_US)
+      .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_CA)
+      .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_GB)
+      .build()
 
     val recipientReceiptSms = barbershop.getBarber<RecipientReceipt, TransactionalSmsDocument>()
 
     val specEN_US = recipientReceiptSms.render(sandy50Receipt, EN_US)
     assertEquals(
-        "Sandy Winchester sent you \$50. It will be available at 2019-05-21T16:02:00Z. Cancel here: https://cash.app/cancel/123",
-        specEN_US.sms_body)
+      "Sandy Winchester sent you \$50. It will be available at 2019-05-21T16:02:00Z. Cancel here: https://cash.app/cancel/123",
+      specEN_US.sms_body
+    )
     val specEN_CA = recipientReceiptSms.render(sandy50Receipt, EN_CA)
     assertEquals(
-        "Sandy Winchester sent you \$50. It will be available at 2019-05-21T16:02:00Z. Cancel here: https://cash.app/cancel/123 Eh?",
-        specEN_CA.sms_body)
+      "Sandy Winchester sent you \$50. It will be available at 2019-05-21T16:02:00Z. Cancel here: https://cash.app/cancel/123 Eh?",
+      specEN_CA.sms_body
+    )
     val specEN_GB = recipientReceiptSms.render(sandy50Receipt, EN_GB)
     assertEquals(
-        "Sandy Winchester sent you \$50. It will be available at 2019-05-21T16:02:00Z. Cancel here: https://cash.app/cancel/123 The Queen approves.",
-        specEN_GB.sms_body)
+      "Sandy Winchester sent you \$50. It will be available at 2019-05-21T16:02:00Z. Cancel here: https://cash.app/cancel/123 The Queen approves.",
+      specEN_GB.sms_body
+    )
   }
 
   @Test
   fun `Render succeeds by fallback for a requested locale that is not installed`() {
     val barber = BarbershopBuilder()
-        .installDocument<TransactionalSmsDocument>()
-        .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_US)
-        .build()
+      .installDocument<TransactionalSmsDocument>()
+      .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_US)
+      .build()
 
     val spec = barber.getBarber<RecipientReceipt, TransactionalSmsDocument>()
-        .render(sandy50Receipt, EN_CA)
+      .render(sandy50Receipt, EN_CA)
 
     assertThat(spec).isEqualTo(
-        TransactionalSmsDocument(
-            sms_body = "Sandy Winchester sent you \$50. It will be available at 2019-05-21T16:02:00Z. Cancel here: https://cash.app/cancel/123"
-        )
+      TransactionalSmsDocument(
+        sms_body = "Sandy Winchester sent you \$50. It will be available at 2019-05-21T16:02:00Z. Cancel here: https://cash.app/cancel/123"
+      )
     )
   }
 
   @Test
   fun `BarberField annotation configures Mustache render encoding per field`() {
     val barber = BarbershopBuilder()
-        .installDocument<EncodingTestDocument>()
-        .installDocumentTemplate<InvestmentPurchase>(
-            investmentPurchaseEncodingDocumentTemplateEN_US)
-        .build()
+      .installDocument<EncodingTestDocument>()
+      .installDocumentTemplate<InvestmentPurchase>(
+        investmentPurchaseEncodingDocumentTemplateEN_US
+      )
+      .build()
 
     val spec = barber.getBarber<InvestmentPurchase, EncodingTestDocument>()
-        .render(mcDonaldsInvestmentPurchase, EN_US)
+      .render(mcDonaldsInvestmentPurchase, EN_US)
 
     assertThat(spec).isEqualTo(
-        EncodingTestDocument(
-            no_annotation_field = "You purchased 100 shares of McDonald&#39;s.",
-            default_field = "You purchased 100 shares of McDonald&#39;s.",
-            html_field = "You purchased 100 shares of McDonald&#39;s.",
-            plaintext_field = "You purchased 100 shares of McDonald's."
-        )
+      EncodingTestDocument(
+        no_annotation_field = "You purchased 100 shares of McDonald&#39;s.",
+        default_field = "You purchased 100 shares of McDonald&#39;s.",
+        html_field = "You purchased 100 shares of McDonald&#39;s.",
+        plaintext_field = "You purchased 100 shares of McDonald's.",
+        url_field = mcDonaldsInvestmentPurchaseUrl,
+      )
     )
   }
 
@@ -271,34 +279,43 @@ class BarberTest {
   fun `Can install and render multiple versions`() {
     val key = recipientReceiptSmsDocumentTemplateEN_US.fields.keys.first()
     val field = recipientReceiptSmsDocumentTemplateEN_US.fields.values.first()
-    val v1 = recipientReceiptSmsDocumentTemplateEN_US.copy(fields = mapOf(key to "$field v1"),
-        version = 1)
-    val v2 = recipientReceiptSmsDocumentTemplateEN_US.copy(fields = mapOf(key to "$field v2"),
-        version = 2)
-    val v3 = recipientReceiptSmsDocumentTemplateEN_US.copy(fields = mapOf(key to "$field v3"),
-        version = 3)
+    val v1 = recipientReceiptSmsDocumentTemplateEN_US.copy(
+      fields = mapOf(key to "$field v1"),
+      version = 1
+    )
+    val v2 = recipientReceiptSmsDocumentTemplateEN_US.copy(
+      fields = mapOf(key to "$field v2"),
+      version = 2
+    )
+    val v3 = recipientReceiptSmsDocumentTemplateEN_US.copy(
+      fields = mapOf(key to "$field v3"),
+      version = 3
+    )
 
     val barbershop = BarbershopBuilder()
-        .installDocument<TransactionalSmsDocument>()
-        .installDocumentTemplate<RecipientReceipt>(v1)
-        .installDocumentTemplate<RecipientReceipt>(v2)
-        .installDocumentTemplate<RecipientReceipt>(v3)
-        .build()
+      .installDocument<TransactionalSmsDocument>()
+      .installDocumentTemplate<RecipientReceipt>(v1)
+      .installDocumentTemplate<RecipientReceipt>(v2)
+      .installDocumentTemplate<RecipientReceipt>(v3)
+      .build()
 
     val recipientReceiptSms = barbershop.getBarber<RecipientReceipt, TransactionalSmsDocument>()
 
     val specV1 = recipientReceiptSms.render(sandy50Receipt, EN_US, 1)
     assertEquals(
-        "Sandy Winchester sent you \$50. It will be available at 2019-05-21T16:02:00Z. Cancel here: https://cash.app/cancel/123 v1",
-        specV1.sms_body)
+      "Sandy Winchester sent you \$50. It will be available at 2019-05-21T16:02:00Z. Cancel here: https://cash.app/cancel/123 v1",
+      specV1.sms_body
+    )
     val specV2 = recipientReceiptSms.render(sandy50Receipt, EN_US, 2)
     assertEquals(
-        "Sandy Winchester sent you \$50. It will be available at 2019-05-21T16:02:00Z. Cancel here: https://cash.app/cancel/123 v2",
-        specV2.sms_body)
+      "Sandy Winchester sent you \$50. It will be available at 2019-05-21T16:02:00Z. Cancel here: https://cash.app/cancel/123 v2",
+      specV2.sms_body
+    )
     val specV3 = recipientReceiptSms.render(sandy50Receipt, EN_US, 3)
     assertEquals(
-        "Sandy Winchester sent you \$50. It will be available at 2019-05-21T16:02:00Z. Cancel here: https://cash.app/cancel/123 v3",
-        specV3.sms_body)
+      "Sandy Winchester sent you \$50. It will be available at 2019-05-21T16:02:00Z. Cancel here: https://cash.app/cancel/123 v3",
+      specV3.sms_body
+    )
   }
 
   @Test
@@ -307,47 +324,57 @@ class BarberTest {
     val field = recipientReceiptSmsDocumentTemplateEN_US.fields.values.first()
 
     val v1 = recipientReceiptSmsDocumentTemplateEN_US.copy(
-        fields = mapOf(key to "New template with no fields v1"), version = 1)
-        .toProto()
-        .copy(source_signature = "")
+      fields = mapOf(key to "New template with no fields v1"), version = 1
+    )
+      .toProto()
+      .copy(source_signature = "")
 
-    val v2 = recipientReceiptSmsDocumentTemplateEN_US.copy(fields = mapOf(key to "$field v2"),
-        version = 2)
+    val v2 = recipientReceiptSmsDocumentTemplateEN_US.copy(
+      fields = mapOf(key to "$field v2"),
+      version = 2
+    )
 
     val v3sourceSignature = BarberSignature(
-        BarberSignature(v2.toProto().source_signature!!).fields + mapOf(
-            "new_variable_not_supported_yet" to app.cash.protos.barber.api.BarberSignature.Type.STRING))
+      BarberSignature(v2.toProto().source_signature!!).fields + mapOf(
+        "new_variable_not_supported_yet" to app.cash.protos.barber.api.BarberSignature.Type.STRING
+      )
+    )
     val v3 = recipientReceiptSmsDocumentTemplateEN_US.copy(
-        fields = mapOf(key to "$field {{ new_variable_not_supported_yet }} v3"), version = 3)
-        .toProto()
-        .copy(source_signature = v3sourceSignature.signature)
+      fields = mapOf(key to "$field {{ new_variable_not_supported_yet }} v3"), version = 3
+    )
+      .toProto()
+      .copy(source_signature = v3sourceSignature.signature)
 
     val barbershop = BarbershopBuilder()
-        .installDocument<TransactionalSmsDocument>()
-        .installDocumentTemplate(v1)
-        .installDocumentTemplate(v2.toProto())
-        .installDocumentTemplate(v3)
-        .setVersionResolver(SpecifiedOrNewestCompatibleVersionResolver)
-        .build()
+      .installDocument<TransactionalSmsDocument>()
+      .installDocumentTemplate(v1)
+      .installDocumentTemplate(v2.toProto())
+      .installDocumentTemplate(v3)
+      .setVersionResolver(SpecifiedOrNewestCompatibleVersionResolver)
+      .build()
 
     val recipientReceiptSms = barbershop.getBarber<RecipientReceipt, TransactionalSmsDocument>()
 
     val specV1 = recipientReceiptSms.render(sandy50Receipt, EN_US, 1)
     assertEquals(
-        "New template with no fields v1",
-        specV1.sms_body)
+      "New template with no fields v1",
+      specV1.sms_body
+    )
     val specV2 = recipientReceiptSms.render(sandy50Receipt, EN_US, 2)
     assertEquals(
-        "Sandy Winchester sent you \$50. It will be available at 2019-05-21T16:02:00Z. Cancel here: https://cash.app/cancel/123 v2",
-        specV2.sms_body)
+      "Sandy Winchester sent you \$50. It will be available at 2019-05-21T16:02:00Z. Cancel here: https://cash.app/cancel/123 v2",
+      specV2.sms_body
+    )
     val specV3 = recipientReceiptSms.render(sandy50Receipt, EN_US, 3)
     assertEquals(
-        "Sandy Winchester sent you \$50. It will be available at 2019-05-21T16:02:00Z. Cancel here: https://cash.app/cancel/123 v2",
-        specV3.sms_body)
+      "Sandy Winchester sent you \$50. It will be available at 2019-05-21T16:02:00Z. Cancel here: https://cash.app/cancel/123 v2",
+      specV3.sms_body
+    )
     val specMaxCompatible = recipientReceiptSms.render(sandy50Receipt, EN_US)
     assertEquals(
-        "Sandy Winchester sent you \$50. It will be available at 2019-05-21T16:02:00Z. Cancel here: https://cash.app/cancel/123 v2",
-        specMaxCompatible.sms_body)
+      "Sandy Winchester sent you \$50. It will be available at 2019-05-21T16:02:00Z. Cancel here: https://cash.app/cancel/123 v2",
+      specMaxCompatible.sms_body
+    )
   }
 
   @Test
@@ -356,50 +383,60 @@ class BarberTest {
     val field = recipientReceiptSmsDocumentTemplateEN_US.fields.values.first()
 
     val v1 = recipientReceiptSmsDocumentTemplateEN_US.copy(
-        fields = mapOf(key to "New template with no fields v1"), version = 1)
-        .toProto()
-        .copy(source_signature = "")
+      fields = mapOf(key to "New template with no fields v1"), version = 1
+    )
+      .toProto()
+      .copy(source_signature = "")
 
-    val v2 = recipientReceiptSmsDocumentTemplateEN_US.copy(fields = mapOf(key to "$field v2"),
-        version = 2)
+    val v2 = recipientReceiptSmsDocumentTemplateEN_US.copy(
+      fields = mapOf(key to "$field v2"),
+      version = 2
+    )
 
     val v3sourceSignature = BarberSignature(
-        BarberSignature(v2.toProto().source_signature!!).fields + mapOf(
-            "new_variable_not_supported_yet" to app.cash.protos.barber.api.BarberSignature.Type.STRING))
+      BarberSignature(v2.toProto().source_signature!!).fields + mapOf(
+        "new_variable_not_supported_yet" to app.cash.protos.barber.api.BarberSignature.Type.STRING
+      )
+    )
     val v3 = recipientReceiptSmsDocumentTemplateEN_US.copy(
-        fields = mapOf(key to "$field {{ new_variable_not_supported_yet }} v3"), version = 3)
-        .toProto()
-        .copy(
-            source_signature = v3sourceSignature.signature,
-            locale = ES_US.locale
-        )
+      fields = mapOf(key to "$field {{ new_variable_not_supported_yet }} v3"), version = 3
+    )
+      .toProto()
+      .copy(
+        source_signature = v3sourceSignature.signature,
+        locale = ES_US.locale
+      )
 
     val barbershop = BarbershopBuilder()
-        .installDocument<TransactionalSmsDocument>()
-        .installDocumentTemplate(v1)
-        .installDocumentTemplate(v2.toProto())
-        .installDocumentTemplate(v3)
-        .setVersionResolver(SpecifiedOrNewestCompatibleVersionResolver)
-        .build()
+      .installDocument<TransactionalSmsDocument>()
+      .installDocumentTemplate(v1)
+      .installDocumentTemplate(v2.toProto())
+      .installDocumentTemplate(v3)
+      .setVersionResolver(SpecifiedOrNewestCompatibleVersionResolver)
+      .build()
 
     val recipientReceiptSms = barbershop.getBarber<RecipientReceipt, TransactionalSmsDocument>()
 
     val specV1 = recipientReceiptSms.render(sandy50Receipt, ES_US, 1)
     assertEquals(
-        "New template with no fields v1",
-        specV1.sms_body)
+      "New template with no fields v1",
+      specV1.sms_body
+    )
     val specV2 = recipientReceiptSms.render(sandy50Receipt, ES_US, 2)
     assertEquals(
-        "Sandy Winchester sent you \$50. It will be available at 2019-05-21T16:02:00Z. Cancel here: https://cash.app/cancel/123 v2",
-        specV2.sms_body)
+      "Sandy Winchester sent you \$50. It will be available at 2019-05-21T16:02:00Z. Cancel here: https://cash.app/cancel/123 v2",
+      specV2.sms_body
+    )
     val specV3 = recipientReceiptSms.render(sandy50Receipt, ES_US, 3)
     assertEquals(
-        "Sandy Winchester sent you \$50. It will be available at 2019-05-21T16:02:00Z. Cancel here: https://cash.app/cancel/123 v2",
-        specV3.sms_body)
+      "Sandy Winchester sent you \$50. It will be available at 2019-05-21T16:02:00Z. Cancel here: https://cash.app/cancel/123 v2",
+      specV3.sms_body
+    )
     val specMaxCompatible = recipientReceiptSms.render(sandy50Receipt, ES_US)
     assertEquals(
-        "Sandy Winchester sent you \$50. It will be available at 2019-05-21T16:02:00Z. Cancel here: https://cash.app/cancel/123 v2",
-        specMaxCompatible.sms_body)
+      "Sandy Winchester sent you \$50. It will be available at 2019-05-21T16:02:00Z. Cancel here: https://cash.app/cancel/123 v2",
+      specMaxCompatible.sms_body
+    )
   }
 
   @Test
@@ -408,18 +445,24 @@ class BarberTest {
     val field = recipientReceiptSmsDocumentTemplateEN_US.fields.values.first()
 
     val v1 = recipientReceiptSmsDocumentTemplateEN_US.copy(
-      fields = mapOf(key to "New template with no fields v1"), version = 1)
+      fields = mapOf(key to "New template with no fields v1"), version = 1
+    )
       .toProto()
       .copy(source_signature = "")
 
-    val v2 = recipientReceiptSmsDocumentTemplateEN_US.copy(fields = mapOf(key to "$field v2"),
-      version = 2)
+    val v2 = recipientReceiptSmsDocumentTemplateEN_US.copy(
+      fields = mapOf(key to "$field v2"),
+      version = 2
+    )
 
     val v3sourceSignature = BarberSignature(
       BarberSignature(v2.toProto().source_signature!!).fields + mapOf(
-        "new_variable_not_supported_yet" to app.cash.protos.barber.api.BarberSignature.Type.STRING))
+        "new_variable_not_supported_yet" to app.cash.protos.barber.api.BarberSignature.Type.STRING
+      )
+    )
     val v3 = recipientReceiptSmsDocumentTemplateEN_US.copy(
-      fields = mapOf(key to "$field {{ new_variable_not_supported_yet }} v3"), version = 3)
+      fields = mapOf(key to "$field {{ new_variable_not_supported_yet }} v3"), version = 3
+    )
       .toProto()
       .copy(
         source_signature = v3sourceSignature.signature,
@@ -438,85 +481,103 @@ class BarberTest {
     val specV1 = recipientReceiptSms.render(sandy50Receipt, ES_US, 1)
     assertEquals(
       "New template with no fields v1",
-      specV1.sms_body)
+      specV1.sms_body
+    )
     val specV2 = recipientReceiptSms.render(sandy50Receipt, ES_US, 2)
     assertEquals(
       "Sandy Winchester sent you \$50. It will be available at 2019-05-21T16:02:00Z. Cancel here: https://cash.app/cancel/123 v2",
-      specV2.sms_body)
+      specV2.sms_body
+    )
     val incompatibleVersionException = assertFailsWith<BarberException> {
       recipientReceiptSms.render(sandy50Receipt, ES_US, 3)
     }
-    assertEquals("""
+    assertEquals(
+      """
       |Errors
       |1) Unable to resolve compatible DocumentTemplate [version=3] for [templateToken=recipientReceipt]
       |[compatibleOptions=[1, 2]]
       |
-    """.trimMargin(), incompatibleVersionException.toString())
+    """.trimMargin(), incompatibleVersionException.toString()
+    )
     val specMaxCompatible = recipientReceiptSms.render(sandy50Receipt, ES_US)
     assertEquals(
       "Sandy Winchester sent you \$50. It will be available at 2019-05-21T16:02:00Z. Cancel here: https://cash.app/cancel/123 v2",
-      specMaxCompatible.sms_body)
+      specMaxCompatible.sms_body
+    )
   }
 
   @Test
   fun `Barber render falls back on latest version it can support if document target removed in newer version`() {
     val barbershop = BarbershopBuilder()
-        .installDocument<TransactionalEmailDocument>()
-        .installDocument<EncodingTestDocument>()
-        .installDocument<TransactionalSmsDocument>()
-        .installDocumentTemplate<MultiVersionDocumentTargetChangeDocumentData>(multiVersionDocumentTarget_v3_emailSms)
-        .installDocumentTemplate<MultiVersionDocumentTargetChangeDocumentData>(multiVersionDocumentTarget_v4_email)
-        .setVersionResolver(SpecifiedOrNewestCompatibleVersionResolver)
-        .build()
+      .installDocument<TransactionalEmailDocument>()
+      .installDocument<EncodingTestDocument>()
+      .installDocument<TransactionalSmsDocument>()
+      .installDocumentTemplate<MultiVersionDocumentTargetChangeDocumentData>(
+        multiVersionDocumentTarget_v3_emailSms
+      )
+      .installDocumentTemplate<MultiVersionDocumentTargetChangeDocumentData>(
+        multiVersionDocumentTarget_v4_email
+      )
+      .setVersionResolver(SpecifiedOrNewestCompatibleVersionResolver)
+      .build()
 
-    val targetDocumentsVersion1 = barbershop.getTargetDocuments<MultiVersionDocumentTargetChangeDocumentData>(
-        multiVersionDocumentTarget_v3_emailSms.version)
-    assertEquals(setOf(TransactionalEmailDocument::class, TransactionalSmsDocument::class),
-        targetDocumentsVersion1)
-    val targetDocumentsVersion2 = barbershop.getTargetDocuments<MultiVersionDocumentTargetChangeDocumentData>(
-        multiVersionDocumentTarget_v4_email.version)
+    val targetDocumentsVersion1 =
+      barbershop.getTargetDocuments<MultiVersionDocumentTargetChangeDocumentData>(
+        multiVersionDocumentTarget_v3_emailSms.version
+      )
+    assertEquals(
+      setOf(TransactionalEmailDocument::class, TransactionalSmsDocument::class),
+      targetDocumentsVersion1
+    )
+    val targetDocumentsVersion2 =
+      barbershop.getTargetDocuments<MultiVersionDocumentTargetChangeDocumentData>(
+        multiVersionDocumentTarget_v4_email.version
+      )
     assertEquals(setOf(TransactionalEmailDocument::class), targetDocumentsVersion2)
-    val targetDocumentsDefaultVersion = barbershop.getTargetDocuments<MultiVersionDocumentTargetChangeDocumentData>()
+    val targetDocumentsDefaultVersion =
+      barbershop.getTargetDocuments<MultiVersionDocumentTargetChangeDocumentData>()
     assertEquals(setOf(TransactionalEmailDocument::class), targetDocumentsDefaultVersion)
 
     // Check that these can all render successfully without throwing BarberException
     val emailRendersWithDefaultVersion =
-        barbershop.getBarber<MultiVersionDocumentTargetChangeDocumentData, TransactionalEmailDocument>()
-            .render(multiVersionDocumentTargetChange, EN_US)
+      barbershop.getBarber<MultiVersionDocumentTargetChangeDocumentData, TransactionalEmailDocument>()
+        .render(multiVersionDocumentTargetChange, EN_US)
     assertEquals("v4", emailRendersWithDefaultVersion.subject)
     val emailRendersWithVersion3 =
-        barbershop.getBarber<MultiVersionDocumentTargetChangeDocumentData, TransactionalEmailDocument>()
-            .render(multiVersionDocumentTargetChange, EN_US, 3)
+      barbershop.getBarber<MultiVersionDocumentTargetChangeDocumentData, TransactionalEmailDocument>()
+        .render(multiVersionDocumentTargetChange, EN_US, 3)
     assertEquals("v3", emailRendersWithVersion3.subject)
     val emailRendersWithVersion4 =
-        barbershop.getBarber<MultiVersionDocumentTargetChangeDocumentData, TransactionalEmailDocument>()
-            .render(multiVersionDocumentTargetChange, EN_US, 4)
+      barbershop.getBarber<MultiVersionDocumentTargetChangeDocumentData, TransactionalEmailDocument>()
+        .render(multiVersionDocumentTargetChange, EN_US, 4)
     assertEquals("v4", emailRendersWithVersion4.subject)
 
     val smsRendersWithDefaultVersion =
-        barbershop.getBarber<MultiVersionDocumentTargetChangeDocumentData, TransactionalSmsDocument>()
-            .render(multiVersionDocumentTargetChange, EN_US)
+      barbershop.getBarber<MultiVersionDocumentTargetChangeDocumentData, TransactionalSmsDocument>()
+        .render(multiVersionDocumentTargetChange, EN_US)
     assertEquals("v3", smsRendersWithDefaultVersion.sms_body)
     val smsRendersWithVersion3 =
-        barbershop.getBarber<MultiVersionDocumentTargetChangeDocumentData, TransactionalSmsDocument>()
-            .render(multiVersionDocumentTargetChange, EN_US, 3)
+      barbershop.getBarber<MultiVersionDocumentTargetChangeDocumentData, TransactionalSmsDocument>()
+        .render(multiVersionDocumentTargetChange, EN_US, 3)
     assertEquals("v3", smsRendersWithVersion3.sms_body)
     // Falls back to v3 since v4 doesn't support SMS
     val smsRendersWithVersion4 =
-        barbershop.getBarber<MultiVersionDocumentTargetChangeDocumentData, TransactionalSmsDocument>()
-            .render(multiVersionDocumentTargetChange, EN_US, 4)
+      barbershop.getBarber<MultiVersionDocumentTargetChangeDocumentData, TransactionalSmsDocument>()
+        .render(multiVersionDocumentTargetChange, EN_US, 4)
     assertEquals("v3", smsRendersWithVersion4.sms_body)
 
     // Blows up when trying to render template that doesn't have Document as Target
     val exception = assertFailsWith<BarberException> {
       barbershop.getBarber<MultiVersionDocumentTargetChangeDocumentData, EncodingTestDocument>()
     }
-    assertEquals("""
+    assertEquals(
+      """
       |Errors
       |1) Failed to get Barber<app.cash.barber.examples.EncodingTestDocument>(templateToken=multiVersionDocumentTargetChange)
       |Document [class app.cash.barber.examples.EncodingTestDocument] is not installed in Barbershop
       |
-    """.trimMargin(), exception.toString())
+    """.trimMargin(), exception.toString()
+    )
   }
 
   @Test
@@ -525,8 +586,12 @@ class BarberTest {
       .installDocument<TransactionalEmailDocument>()
       .installDocument<EncodingTestDocument>()
       .installDocument<TransactionalSmsDocument>()
-      .installDocumentTemplate<MultiVersionDocumentTargetChangeDocumentData>(multiVersionDocumentTarget_v3_emailSms)
-      .installDocumentTemplate<MultiVersionDocumentTargetChangeDocumentData>(multiVersionDocumentTarget_v4_email)
+      .installDocumentTemplate<MultiVersionDocumentTargetChangeDocumentData>(
+        multiVersionDocumentTarget_v3_emailSms
+      )
+      .installDocumentTemplate<MultiVersionDocumentTargetChangeDocumentData>(
+        multiVersionDocumentTarget_v4_email
+      )
       .build()
 
     // Throws since v4 doesn't support SMS
@@ -534,35 +599,37 @@ class BarberTest {
       barbershop.getBarber<MultiVersionDocumentTargetChangeDocumentData, TransactionalSmsDocument>()
         .render(multiVersionDocumentTargetChange, EN_US, 4)
     }
-    assertEquals("""
+    assertEquals(
+      """
       |Errors
       |1) Unable to resolve compatible DocumentTemplate [version=4] for [templateToken=multiVersionDocumentTargetChange]
       |[compatibleOptions=[3]]
       |
-    """.trimMargin(), incompatibleVersionException.toString())
+    """.trimMargin(), incompatibleVersionException.toString()
+    )
   }
 
   @Disabled @Test
   fun fieldStemming() {
     val barber = BarbershopBuilder()
-        .installDocument<TransactionalEmailDocument>()
-        .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_US)
-        .build()
+      .installDocument<TransactionalEmailDocument>()
+      .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_US)
+      .build()
 
     val spec = barber.getBarber<RecipientReceipt, TransactionalEmailDocument>()
-        .render(sandy50Receipt, EN_US)
+      .render(sandy50Receipt, EN_US)
 
     assertThat(spec).isEqualTo(
-        TransactionalEmailDocument(
-            subject = "Sandy Winchester sent you $50",
-            headline = "You received $50",
-            short_description = "You’ve received a payment from Sandy Winchester! The money will be in your bank account " +
-                "in 2 days.",
-            primary_button = "Cancel this payment",
-            primary_button_url = "https://cash.app/cancel/123",
-            secondary_button = null,
-            secondary_button_url = null
-        )
+      TransactionalEmailDocument(
+        subject = "Sandy Winchester sent you $50",
+        headline = "You received $50",
+        short_description = "You’ve received a payment from Sandy Winchester! The money will be in your bank account " +
+          "in 2 days.",
+        primary_button = "Cancel this payment",
+        primary_button_url = "https://cash.app/cancel/123",
+        secondary_button = null,
+        secondary_button_url = null
+      )
     )
   }
 }

--- a/barber/src/test/kotlin/app/cash/barber/BarbershopBuilderTest.kt
+++ b/barber/src/test/kotlin/app/cash/barber/BarbershopBuilderTest.kt
@@ -13,6 +13,7 @@ import app.cash.barber.examples.TransactionalSmsDocument
 import app.cash.barber.examples.investmentPurchaseEncodingDocumentTemplateEN_US
 import app.cash.barber.examples.investmentPurchaseShadowEncodingDocumentTemplateEN_US
 import app.cash.barber.examples.mcDonaldsInvestmentPurchase
+import app.cash.barber.examples.mcDonaldsInvestmentPurchaseUrl
 import app.cash.barber.examples.noParametersDocumentTemplate
 import app.cash.barber.examples.plaintextDocumentTemplateEN_US
 import app.cash.barber.examples.recipientReceiptSmsDocumentTemplateEN_CA
@@ -36,44 +37,45 @@ class BarbershopBuilderTest {
   @Test
   fun `Install works`() {
     BarbershopBuilder()
-        .installDocument<TransactionalSmsDocument>()
-        .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_US)
-        .setWarningsAsErrors()
-        .build()
+      .installDocument<TransactionalSmsDocument>()
+      .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_US)
+      .setWarningsAsErrors()
+      .build()
   }
 
   @Test
   fun `Install works regardless of order`() {
     BarbershopBuilder()
-        .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_US)
-        .installDocument<TransactionalSmsDocument>()
-        .setWarningsAsErrors()
-        .build()
+      .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_US)
+      .installDocument<TransactionalSmsDocument>()
+      .setWarningsAsErrors()
+      .build()
   }
 
   @Test
   fun `Install multiple locales`() {
     BarbershopBuilder()
-        .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_US)
-        .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_CA)
-        .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_GB)
-        .installDocument<TransactionalSmsDocument>()
-        .setWarningsAsErrors()
-        .build()
+      .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_US)
+      .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_CA)
+      .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_GB)
+      .installDocument<TransactionalSmsDocument>()
+      .setWarningsAsErrors()
+      .build()
   }
 
   @Test
   fun `Install multiple documents`() {
     BarbershopBuilder()
-        .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsEmailDocumentTemplateEN_US)
-        .installDocumentTemplate<SenderReceipt>(senderReceiptEmailDocumentTemplateEN_US)
-        .installDocumentTemplate<InvestmentPurchase>(
-            investmentPurchaseEncodingDocumentTemplateEN_US)
-        .installDocument<EncodingTestDocument>()
-        .installDocument<TransactionalEmailDocument>()
-        .installDocument<TransactionalSmsDocument>()
-        .setWarningsAsErrors()
-        .build()
+      .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsEmailDocumentTemplateEN_US)
+      .installDocumentTemplate<SenderReceipt>(senderReceiptEmailDocumentTemplateEN_US)
+      .installDocumentTemplate<InvestmentPurchase>(
+        investmentPurchaseEncodingDocumentTemplateEN_US
+      )
+      .installDocument<EncodingTestDocument>()
+      .installDocument<TransactionalEmailDocument>()
+      .installDocument<TransactionalSmsDocument>()
+      .setWarningsAsErrors()
+      .build()
   }
 
   @Test
@@ -86,7 +88,8 @@ class BarbershopBuilderTest {
           )
         )
         .installDocumentTemplate<InvestmentPurchase>(
-          investmentPurchaseEncodingDocumentTemplateEN_US)
+          investmentPurchaseEncodingDocumentTemplateEN_US
+        )
         .installDocument<EncodingTestDocument>()
         .build()
     }
@@ -101,228 +104,253 @@ class BarbershopBuilderTest {
     )
   }
 
-
   @Test
   fun `Fails when DocumentTemplate target Documents are not installed`() {
     val exception = assertFailsWith<BarberException> {
       BarbershopBuilder()
-          .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_US)
-          .installDocumentTemplate<SenderReceipt>(senderReceiptEmailDocumentTemplateEN_US)
-          .installDocument<TransactionalEmailDocument>()
-          .build()
+        .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_US)
+        .installDocumentTemplate<SenderReceipt>(senderReceiptEmailDocumentTemplateEN_US)
+        .installDocument<TransactionalEmailDocument>()
+        .build()
     }
-    assertEquals("""
+    assertEquals(
+      """
       |Errors
       |1) Attempted to install DocumentTemplate without the corresponding Document being installed.
       |Not installed DocumentTemplate.target_signatures:
       |[BarberSignature(signature=sms_body,1, fields={sms_body=STRING})]
       |
       """.trimMargin(),
-        exception.toString())
+      exception.toString()
+    )
   }
 
   @Test
   fun `Fails when DocumentTemplate installed with non-source DocumentData`() {
     val exception = assertFailsWith<BarberException> {
       BarbershopBuilder()
-          .installDocumentTemplate<SenderReceipt>(recipientReceiptSmsDocumentTemplateEN_US)
-          .installDocument<TransactionalSmsDocument>()
-          .build()
+        .installDocumentTemplate<SenderReceipt>(recipientReceiptSmsDocumentTemplateEN_US)
+        .installDocument<TransactionalSmsDocument>()
+        .build()
     }
-    assertEquals("""
+    assertEquals(
+      """
       |Errors
       |1) Attempted to install DocumentTemplate with a DocumentData not specified in the DocumentTemplate source
       |DocumentTemplate.source: app.cash.barber.examples.RecipientReceipt
       |DocumentData: app.cash.barber.examples.SenderReceipt
       |
-      """.trimMargin(), exception.toString())
+      """.trimMargin(), exception.toString()
+    )
   }
 
   @Test
   fun `Passes when DocumentTemplate naively matches source signature since types all resolve to String`() {
     BarbershopBuilder()
-        .installDocumentTemplate(recipientReceiptSmsEmailDocumentTemplateEN_US.toProto().copy(
-            source_signature = BarberSignature(
-                mapOf(
-                    "sender" to app.cash.protos.barber.api.BarberSignature.Type.STRING,
-                    "amount" to app.cash.protos.barber.api.BarberSignature.Type.STRING,
-                    "cancelUrl" to app.cash.protos.barber.api.BarberSignature.Type.STRING,
-                    "deposit_expected_at" to app.cash.protos.barber.api.BarberSignature.Type.STRING
-                )
-            ).signature
-        ))
-        .installDocument<TransactionalEmailDocument>()
-        .installDocument<TransactionalSmsDocument>()
-        .setWarningsAsErrors()
-        .build()
+      .installDocumentTemplate(
+        recipientReceiptSmsEmailDocumentTemplateEN_US.toProto().copy(
+          source_signature = BarberSignature(
+            mapOf(
+              "sender" to app.cash.protos.barber.api.BarberSignature.Type.STRING,
+              "amount" to app.cash.protos.barber.api.BarberSignature.Type.STRING,
+              "cancelUrl" to app.cash.protos.barber.api.BarberSignature.Type.STRING,
+              "deposit_expected_at" to app.cash.protos.barber.api.BarberSignature.Type.STRING
+            )
+          ).signature
+        )
+      )
+      .installDocument<TransactionalEmailDocument>()
+      .installDocument<TransactionalSmsDocument>()
+      .setWarningsAsErrors()
+      .build()
   }
 
   @Test
   fun `Fails when DocumentTemplate installed where explicit source_signature does not match computed implicit source signature`() {
     val exception = assertFailsWith<BarberException> {
       BarbershopBuilder()
-          .installDocumentTemplate(recipientReceiptSmsEmailDocumentTemplateEN_US.toProto().copy(
-              source_signature = BarberSignature(
-                  mapOf(
-                      "sender" to app.cash.protos.barber.api.BarberSignature.Type.STRING,
-                      "amount" to app.cash.protos.barber.api.BarberSignature.Type.STRING,
-                      "deposit_expected_at" to app.cash.protos.barber.api.BarberSignature.Type.STRING
-                  )
-              ).signature
-          ))
-          .installDocument<TransactionalEmailDocument>()
-          .installDocument<TransactionalSmsDocument>()
-          .build()
+        .installDocumentTemplate(
+          recipientReceiptSmsEmailDocumentTemplateEN_US.toProto().copy(
+            source_signature = BarberSignature(
+              mapOf(
+                "sender" to app.cash.protos.barber.api.BarberSignature.Type.STRING,
+                "amount" to app.cash.protos.barber.api.BarberSignature.Type.STRING,
+                "deposit_expected_at" to app.cash.protos.barber.api.BarberSignature.Type.STRING
+              )
+            ).signature
+          )
+        )
+        .installDocument<TransactionalEmailDocument>()
+        .installDocument<TransactionalSmsDocument>()
+        .build()
     }
-    assertEquals("""
+    assertEquals(
+      """
       |Errors
       |1) Missing variable [cancelUrl] for DocumentData with [templateToken=recipientReceipt] for DocumentTemplate field [Field{key=primary_button_url, template=\{\{cancelUrl\}\}}]
       |
-      """.trimMargin(), exception.toString())
+      """.trimMargin(), exception.toString()
+    )
   }
 
   @Test
   fun `Fails when Document has no parameters`() {
     val exception = assertFailsWith<BarberException> {
       BarbershopBuilder()
-          .installDocument<NoParametersDocument>()
-          .installDocumentTemplate<EmptyDocumentData>(noParametersDocumentTemplate)
-          .build()
+        .installDocument<NoParametersDocument>()
+        .installDocumentTemplate<EmptyDocumentData>(noParametersDocumentTemplate)
+        .build()
     }
-    assertEquals("""
+    assertEquals(
+      """
       |Errors
       |1) No fields included for Document [class app.cash.barber.examples.NoParametersDocument]
       |
-      """.trimMargin(), exception.toString())
+      """.trimMargin(), exception.toString()
+    )
   }
 
   @Test
   fun `Install fails on no DocumentTemplate and DocumentData`() {
     val exception = assertFailsWith<BarberException> {
       BarbershopBuilder()
-          .installDocument<TransactionalEmailDocument>()
-          .build()
+        .installDocument<TransactionalEmailDocument>()
+        .build()
     }
 
     assertEquals(
-        """
+      """
           |Errors
           |1) No DocumentData or DocumentTemplates installed
           |
         """.trimMargin(),
-        exception.toString())
+      exception.toString()
+    )
   }
 
   @Test
   fun `Install warns on missing Document for an installed DocumentTemplate`() {
     val exception = assertFailsWith<BarberException> {
       BarbershopBuilder()
-          .installDocumentTemplate<RecipientReceipt>(investmentPurchaseShadowEncodingDocumentTemplateEN_US)
-          .installDocument<EncodingTestDocument>()
-          .setWarningsAsErrors()
-          .build()
+        .installDocumentTemplate<RecipientReceipt>(
+          investmentPurchaseShadowEncodingDocumentTemplateEN_US
+        )
+        .installDocument<EncodingTestDocument>()
+        .setWarningsAsErrors()
+        .build()
     }
     assertEquals(
-        """
+      """
           |Errors
           |1) Attempted to install DocumentTemplate with a DocumentData not specified in the DocumentTemplate source
           |DocumentTemplate.source: app.cash.barber.examples.InvestmentPurchase
           |DocumentData: app.cash.barber.examples.RecipientReceipt
           |
         """.trimMargin(),
-        exception.toString())
+      exception.toString()
+    )
   }
 
   @Test
   fun `setWarningsAsErrors fails out early for install with no Documents`() {
     val exception = assertFailsWith<BarberException> {
       BarbershopBuilder()
-          .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_US)
-          .build()
+        .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_US)
+        .build()
     }
     assertEquals(
-        """
+      """
           |Errors
           |1) No Documents installed
           |
         """.trimMargin(),
-        exception.toString())
+      exception.toString()
+    )
   }
 
   @Test
   fun `Fails on unused dangling installed Document`() {
     val exception = assertFailsWith<BarberException> {
       BarbershopBuilder()
-          .installDocument<TransactionalEmailDocument>()
-          .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_US)
-          .installDocument<TransactionalSmsDocument>()
-          .setWarningsAsErrors()
-          .build()
+        .installDocument<TransactionalEmailDocument>()
+        .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_US)
+        .installDocument<TransactionalSmsDocument>()
+        .setWarningsAsErrors()
+        .build()
     }
-    assertEquals("""
+    assertEquals(
+      """
       |Warnings
       |1) Document installed that is not used in any installed DocumentTemplates
       |[app.cash.barber.examples.TransactionalEmailDocument]
       |
-      """.trimMargin(), exception.toString())
+      """.trimMargin(), exception.toString()
+    )
   }
 
   @Test
   fun `Renders correctly Documents with shadow fields with different encoding`() {
     val barber = BarbershopBuilder()
-        .installDocumentTemplate<InvestmentPurchase>(
-            investmentPurchaseShadowEncodingDocumentTemplateEN_US)
-        .installDocument<EncodingTestDocument>()
-        .installDocument<ShadowEncodingEverythingPlaintextTestDocument>()
-        .setWarningsAsErrors()
-        .build()
+      .installDocumentTemplate<InvestmentPurchase>(
+        investmentPurchaseShadowEncodingDocumentTemplateEN_US
+      )
+      .installDocument<EncodingTestDocument>()
+      .installDocument<ShadowEncodingEverythingPlaintextTestDocument>()
+      .setWarningsAsErrors()
+      .build()
 
     val specRegular = barber.getBarber<InvestmentPurchase, EncodingTestDocument>()
-        .render(mcDonaldsInvestmentPurchase, Locale.EN_US)
+      .render(mcDonaldsInvestmentPurchase, Locale.EN_US)
 
     assertThat(specRegular).isEqualTo(
-        EncodingTestDocument(
-            no_annotation_field = "You purchased 100 shares of McDonald&#39;s.",
-            default_field = "You purchased 100 shares of McDonald&#39;s.",
-            html_field = "You purchased 100 shares of McDonald&#39;s.",
-            plaintext_field = "You purchased 100 shares of McDonald's."
-        )
+      EncodingTestDocument(
+        no_annotation_field = "You purchased 100 shares of McDonald&#39;s.",
+        default_field = "You purchased 100 shares of McDonald&#39;s.",
+        html_field = "You purchased 100 shares of McDonald&#39;s.",
+        plaintext_field = "You purchased 100 shares of McDonald's.",
+        url_field = mcDonaldsInvestmentPurchaseUrl,
+      )
     )
 
     val specShadow =
-        barber.getBarber<InvestmentPurchase, ShadowEncodingEverythingPlaintextTestDocument>()
-            .render(mcDonaldsInvestmentPurchase, Locale.EN_US)
+      barber.getBarber<InvestmentPurchase, ShadowEncodingEverythingPlaintextTestDocument>()
+        .render(mcDonaldsInvestmentPurchase, Locale.EN_US)
 
     assertThat(specShadow).isEqualTo(
-        ShadowEncodingEverythingPlaintextTestDocument(
-            // Notice all shadowed fields are still rendered with the correct Plaintext encoding
-            // even though they conflict in name with the above target document that has HTML encoding
-            no_annotation_field = "You purchased 100 shares of McDonald's.",
-            default_field = "You purchased 100 shares of McDonald's.",
-            html_field = "You purchased 100 shares of McDonald's.",
-            plaintext_field = "You purchased 100 shares of McDonald's.",
-            non_shadow_field = "You purchased 100 shares of McDonald's."
-        )
+      ShadowEncodingEverythingPlaintextTestDocument(
+        // Notice all shadowed fields are still rendered with the correct Plaintext encoding
+        // even though they conflict in name with the above target document that has HTML encoding
+        no_annotation_field = "You purchased 100 shares of McDonald's.",
+        default_field = "You purchased 100 shares of McDonald's.",
+        html_field = "You purchased 100 shares of McDonald's.",
+        plaintext_field = "You purchased 100 shares of McDonald's.",
+        non_shadow_field = "You purchased 100 shares of McDonald's."
+      )
     )
   }
 
   @Test
   fun `Barbershop does not include documents as targets where template does not satisfy all fields`() {
     val barber = BarbershopBuilder()
-        .installDocumentTemplate<InvestmentPurchase>(
-            investmentPurchaseEncodingDocumentTemplateEN_US)
-        .installDocumentTemplate<SenderReceipt>(plaintextDocumentTemplateEN_US)
-        .installDocument<EncodingTestDocument>()
-        .installDocument<ShadowPlaintextDocument>()
-        .setWarningsAsErrors()
-        .build()
+      .installDocumentTemplate<InvestmentPurchase>(
+        investmentPurchaseEncodingDocumentTemplateEN_US
+      )
+      .installDocumentTemplate<SenderReceipt>(plaintextDocumentTemplateEN_US)
+      .installDocument<EncodingTestDocument>()
+      .installDocument<ShadowPlaintextDocument>()
+      .setWarningsAsErrors()
+      .build()
 
     // investmentPurchaseEncodingDocumentTemplateEN_US only specifies EncodingTestDocument
     //    but can support ShadowPlaintextDocument so it is included
-    assertEquals(setOf(EncodingTestDocument::class, ShadowPlaintextDocument::class),
-        barber.getTargetDocuments(InvestmentPurchase::class.getTemplateToken()))
-    assertEquals(setOf(ShadowPlaintextDocument::class),
-        barber.getTargetDocuments(SenderReceipt::class.getTemplateToken()))
+    assertEquals(
+      setOf(EncodingTestDocument::class, ShadowPlaintextDocument::class),
+      barber.getTargetDocuments(InvestmentPurchase::class.getTemplateToken())
+    )
+    assertEquals(
+      setOf(ShadowPlaintextDocument::class),
+      barber.getTargetDocuments(SenderReceipt::class.getTemplateToken())
+    )
   }
 
   @Test
@@ -352,24 +380,62 @@ class BarbershopBuilderTest {
   @Test
   fun `setDefaultBarberFieldEncoding changes non-annotated field render encoding`() {
     val barber = BarbershopBuilder()
-        .installDocument<EncodingTestDocument>()
-        .installDocumentTemplate<InvestmentPurchase>(
-            investmentPurchaseEncodingDocumentTemplateEN_US)
-        .setDefaultBarberFieldEncoding(BarberFieldEncoding.STRING_PLAINTEXT)
-        .build()
+      .installDocument<EncodingTestDocument>()
+      .installDocumentTemplate<InvestmentPurchase>(
+        investmentPurchaseEncodingDocumentTemplateEN_US
+      )
+      .setDefaultBarberFieldEncoding(BarberFieldEncoding.STRING_PLAINTEXT)
+      .build()
 
     val spec = barber.getBarber<InvestmentPurchase, EncodingTestDocument>()
-        .render(mcDonaldsInvestmentPurchase, Locale.EN_US)
+      .render(mcDonaldsInvestmentPurchase, Locale.EN_US)
 
     assertThat(spec).isEqualTo(
-        EncodingTestDocument(
-            // Using the default HTML encoding, the apostrophe in no_annotation_field have been escaped.
-            no_annotation_field = "You purchased 100 shares of McDonald's.",
-            default_field = "You purchased 100 shares of McDonald&#39;s.",
-            html_field = "You purchased 100 shares of McDonald&#39;s.",
-            plaintext_field = "You purchased 100 shares of McDonald's."
-        )
+      EncodingTestDocument(
+        // Using the default HTML encoding, the apostrophe in no_annotation_field have been escaped.
+        no_annotation_field = "You purchased 100 shares of McDonald's.",
+        default_field = "You purchased 100 shares of McDonald&#39;s.",
+        html_field = "You purchased 100 shares of McDonald&#39;s.",
+        plaintext_field = "You purchased 100 shares of McDonald's.",
+        url_field = "https://cash.app/go/InvestConfirmAction_input?strOrigTrackNum=9400111899561379412019",
+      )
     )
+  }
+
+  @Test
+  fun `HttpUrl field encoding escapes non-URL characters to prevent code injection`() {
+    val iframeInjection = "<iframe>test</iframe>"
+    val cssKeyframeInjection = "<style>@keyframes x{}</style><b style=\"animation-n"
+    val htmlCode = "<h1>test2</h1>"
+    val javascriptAlertInjection = "javascript:alert`1`\t"
+
+    val barber = BarbershopBuilder()
+      .installDocument<EncodingTestDocument>()
+      .installDocumentTemplate<InvestmentPurchase>(
+        investmentPurchaseEncodingDocumentTemplateEN_US
+      )
+      .setDefaultBarberFieldEncoding(BarberFieldEncoding.STRING_PLAINTEXT)
+      .build()
+
+    val spec = barber.getBarber<InvestmentPurchase, EncodingTestDocument>()
+      .render(mcDonaldsInvestmentPurchase.copy(
+        url = "https://test.com/$iframeInjection$cssKeyframeInjection$htmlCode$javascriptAlertInjection",
+      ), Locale.EN_US)
+
+    assertThat(spec).isEqualTo(
+      EncodingTestDocument(
+        // Using the default HTML encoding, the apostrophe in no_annotation_field have been escaped.
+        no_annotation_field = "You purchased 100 shares of McDonald's.",
+        default_field = "You purchased 100 shares of McDonald&#39;s.",
+        html_field = "You purchased 100 shares of McDonald&#39;s.",
+        plaintext_field = "You purchased 100 shares of McDonald's.",
+        url_field = "https://test.com/%3Ciframe%3Etest%3C/iframe%3E%3Cstyle%3E@keyframes%20x%7B%7D%3C/style%3E%3Cb%20style=%22animation-n%3Ch1%3Etest2%3C/h1%3Ejavascript:alert%601%60",
+      )
+    )
+    assertThat(spec.url_field).doesNotContain(iframeInjection)
+    assertThat(spec.url_field).doesNotContain(cssKeyframeInjection)
+    assertThat(spec.url_field).doesNotContain(htmlCode)
+    assertThat(spec.url_field).doesNotContain(javascriptAlertInjection)
   }
 
   @Test
@@ -379,27 +445,28 @@ class BarbershopBuilderTest {
     ) : DocumentData
 
     val tradeReceiptEN_US = DocumentTemplate(
-        fields = mapOf(
-            "sms_body" to "You bought {{ shares }} shares of {{ ticker }}."
-        ),
-        source = TradeReceipt::class,
-        targets = setOf(TransactionalSmsDocument::class),
-        locale = Locale.EN_US
+      fields = mapOf(
+        "sms_body" to "You bought {{ shares }} shares of {{ ticker }}."
+      ),
+      source = TradeReceipt::class,
+      targets = setOf(TransactionalSmsDocument::class),
+      locale = Locale.EN_US
     )
 
     val exception = assertFailsWith<BarberException> {
       BarbershopBuilder()
-          .installDocument<TransactionalSmsDocument>()
-          .installDocumentTemplate<TradeReceipt>(tradeReceiptEN_US)
-          .build()
+        .installDocument<TransactionalSmsDocument>()
+        .installDocumentTemplate<TradeReceipt>(tradeReceiptEN_US)
+        .build()
     }
     assertEquals(
-        """
+      """
         |Errors
         |1) Missing variable [shares] for DocumentData with [templateToken=tradeReceipt] for DocumentTemplate field [Field{key=sms_body, template=You bought \{\{ shares \}\} shares of \{\{ ticker \}\}.}]
         |
       """.trimMargin(),
-        exception.toString())
+      exception.toString()
+    )
   }
 
   @Test
@@ -410,116 +477,119 @@ class BarbershopBuilderTest {
     ) : DocumentData
 
     val tradeReceiptEN_US = DocumentTemplate(
-        fields = mapOf(
-            "sms_body" to "Welcome to the {{ ticker }} shareholder family!"
-        ),
-        source = TradeReceipt::class,
-        targets = setOf(TransactionalSmsDocument::class),
-        locale = Locale.EN_US
+      fields = mapOf(
+        "sms_body" to "Welcome to the {{ ticker }} shareholder family!"
+      ),
+      source = TradeReceipt::class,
+      targets = setOf(TransactionalSmsDocument::class),
+      locale = Locale.EN_US
     )
 
     val exception = assertFailsWith<BarberException> {
       BarbershopBuilder()
-          .installDocument<TransactionalSmsDocument>()
-          .installDocumentTemplate<TradeReceipt>(tradeReceiptEN_US)
-          .setWarningsAsErrors()
-          .build()
+        .installDocument<TransactionalSmsDocument>()
+        .installDocumentTemplate<TradeReceipt>(tradeReceiptEN_US)
+        .setWarningsAsErrors()
+        .build()
     }
     assertEquals(
-        """
+      """
         |Warnings
         |1) Unused DocumentData variable [shares] in Source signature [shares,1;ticker,1] with no
         |usage in DocumentTemplate: [templateToken=tradeReceipt][locale=en-US][version=1] 
         |
       """.trimMargin(),
-        exception.toString())
+      exception.toString()
+    )
   }
 
   @Test
   fun `Fails when DocumentTemplate does not have sufficient fields for target Document`() {
     val recipientReceiptDocumentTemplate = DocumentTemplate(
-        fields = mapOf(
-            "subject" to "{{ sender }} sent {{ amount }} on {{ deposit_expected_at }}. Cancel here: {{ cancelUrl }}"
-        ),
-        source = RecipientReceipt::class,
-        targets = setOf(TransactionalSmsDocument::class),
-        locale = Locale.EN_US
+      fields = mapOf(
+        "subject" to "{{ sender }} sent {{ amount }} on {{ deposit_expected_at }}. Cancel here: {{ cancelUrl }}"
+      ),
+      source = RecipientReceipt::class,
+      targets = setOf(TransactionalSmsDocument::class),
+      locale = Locale.EN_US
     )
 
     val exception = assertFailsWith<BarberException> {
       BarbershopBuilder()
-          .installDocumentTemplate<RecipientReceipt>(recipientReceiptDocumentTemplate)
-          .installDocument<TransactionalSmsDocument>()
-          .build()
+        .installDocumentTemplate<RecipientReceipt>(recipientReceiptDocumentTemplate)
+        .installDocument<TransactionalSmsDocument>()
+        .build()
     }
     assertEquals(
-        """
+      """
         |Errors
         |1) Installed DocumentTemplate: [templateToken=recipientReceipt][locale=en-US][version=1]
         |missing required fields for Document targets:
         |[document=app.cash.barber.examples.TransactionalSmsDocument] requires missing [field=sms_body]
         |
       """.trimMargin(),
-        exception.toString())
+      exception.toString()
+    )
   }
 
   @Test
   fun `DocumentTemplate has extra fields unused by target Documents`() {
     val recipientReceiptDocumentData = DocumentTemplate(
-        fields = mapOf(
-            "sms_body" to "{{ sender }} sent you {{ amount }} on {{ deposit_expected_at }}. Cancel here: {{ cancelUrl }}",
-            "extra_field" to "This field is unused in any target document"
-        ),
-        source = RecipientReceipt::class,
-        targets = setOf(TransactionalSmsDocument::class),
-        locale = Locale.EN_US
+      fields = mapOf(
+        "sms_body" to "{{ sender }} sent you {{ amount }} on {{ deposit_expected_at }}. Cancel here: {{ cancelUrl }}",
+        "extra_field" to "This field is unused in any target document"
+      ),
+      source = RecipientReceipt::class,
+      targets = setOf(TransactionalSmsDocument::class),
+      locale = Locale.EN_US
     )
 
     val exception = assertFailsWith<BarberException> {
       BarbershopBuilder()
-          .installDocumentTemplate<RecipientReceipt>(recipientReceiptDocumentData)
-          .installDocument<TransactionalSmsDocument>()
-          .build()
+        .installDocumentTemplate<RecipientReceipt>(recipientReceiptDocumentData)
+        .installDocument<TransactionalSmsDocument>()
+        .build()
     }
     assertEquals(
-        """
+      """
         |Errors
         |1) Installed DocumentTemplate has additional fields that are not used in any target Document
         |Additional fields:
         |extra_field
         |
       """.trimMargin(),
-        exception.toString())
+      exception.toString()
+    )
   }
 
   @Test
   fun `Fails on duplicate install of DocumentTemplate`() {
     val first = DocumentTemplate(
-        fields = mapOf(
-            "sms_body" to "first {{ sender }} sent you {{ amount }} on {{ deposit_expected_at }}. Cancel here: {{ cancelUrl }}"
-        ),
-        source = RecipientReceipt::class,
-        targets = setOf(TransactionalSmsDocument::class),
-        locale = Locale.EN_US
+      fields = mapOf(
+        "sms_body" to "first {{ sender }} sent you {{ amount }} on {{ deposit_expected_at }}. Cancel here: {{ cancelUrl }}"
+      ),
+      source = RecipientReceipt::class,
+      targets = setOf(TransactionalSmsDocument::class),
+      locale = Locale.EN_US
     )
     val second = DocumentTemplate(
-        fields = mapOf(
-            "sms_body" to "second {{ sender }} sent you {{ amount }} on {{ deposit_expected_at }}. Cancel here: {{ cancelUrl }}"
-        ),
-        source = RecipientReceipt::class,
-        targets = setOf(TransactionalSmsDocument::class),
-        locale = Locale.EN_US
+      fields = mapOf(
+        "sms_body" to "second {{ sender }} sent you {{ amount }} on {{ deposit_expected_at }}. Cancel here: {{ cancelUrl }}"
+      ),
+      source = RecipientReceipt::class,
+      targets = setOf(TransactionalSmsDocument::class),
+      locale = Locale.EN_US
     )
 
     val exception = assertFailsWith<BarberException> {
       BarbershopBuilder()
-          .installDocumentTemplate<RecipientReceipt>(first)
-          .installDocumentTemplate<RecipientReceipt>(second)
-          .installDocument<TransactionalSmsDocument>()
-          .build()
+        .installDocumentTemplate<RecipientReceipt>(first)
+        .installDocumentTemplate<RecipientReceipt>(second)
+        .installDocument<TransactionalSmsDocument>()
+        .build()
     }
     assertEquals(
-        """
+      """
         |Errors
         |1) Attempted to install DocumentTemplate that will overwrite an already installed locale version
         |DocumentTemplate: [templateToken=recipientReceipt][locale=en-US][version=1]
@@ -530,6 +600,7 @@ class BarbershopBuilderTest {
         |Installed Versions: [1]
         |
       """.trimMargin(),
-        exception.toString())
+      exception.toString()
+    )
   }
 }

--- a/barber/src/test/kotlin/app/cash/barber/examples/EncodingTestDocument.kt
+++ b/barber/src/test/kotlin/app/cash/barber/examples/EncodingTestDocument.kt
@@ -14,5 +14,7 @@ data class EncodingTestDocument(
   @BarberField(encoding = BarberFieldEncoding.STRING_HTML)
   val html_field: String,
   @BarberField(encoding = BarberFieldEncoding.STRING_PLAINTEXT)
-  val plaintext_field: String
+  val plaintext_field: String,
+  @BarberField(encoding = BarberFieldEncoding.STRING_HTTPURL)
+  val url_field: String,
 ) : Document

--- a/barber/src/test/kotlin/app/cash/barber/examples/InvestmentPurchased.kt
+++ b/barber/src/test/kotlin/app/cash/barber/examples/InvestmentPurchased.kt
@@ -4,10 +4,13 @@ import app.cash.barber.models.DocumentData
 
 data class InvestmentPurchase(
   val shares: String,
-  val ticker: String
+  val ticker: String,
+  val url: String
 ) : DocumentData
 
+val mcDonaldsInvestmentPurchaseUrl = "https://cash.app/go/InvestConfirmAction_input?strOrigTrackNum=9400111899561379412019"
 val mcDonaldsInvestmentPurchase = InvestmentPurchase(
-    shares = "100",
-    ticker = "McDonald's"
+  shares = "100",
+  ticker = "McDonald's",
+  url = mcDonaldsInvestmentPurchaseUrl
 )

--- a/barber/src/test/kotlin/app/cash/barber/examples/TestFixtures.kt
+++ b/barber/src/test/kotlin/app/cash/barber/examples/TestFixtures.kt
@@ -1,99 +1,103 @@
 package app.cash.barber.examples
 
-import app.cash.barber.models.DocumentTemplate
 import app.cash.barber.locale.Locale.Companion.EN_CA
 import app.cash.barber.locale.Locale.Companion.EN_GB
 import app.cash.barber.locale.Locale.Companion.EN_US
+import app.cash.barber.models.DocumentTemplate
 
 val recipientReceiptSmsDocumentTemplateEN_US = DocumentTemplate(
-    fields = mapOf(
-        "sms_body" to "{{sender}} sent you {{amount}}. It will be available at {{ deposit_expected_at }}. Cancel here: {{ cancelUrl }}"
-    ),
-    source = RecipientReceipt::class,
-    targets = setOf(TransactionalSmsDocument::class),
-    locale = EN_US
+  fields = mapOf(
+    "sms_body" to "{{sender}} sent you {{amount}}. It will be available at {{ deposit_expected_at }}. Cancel here: {{ cancelUrl }}"
+  ),
+  source = RecipientReceipt::class,
+  targets = setOf(TransactionalSmsDocument::class),
+  locale = EN_US
 )
 
 val recipientReceiptSmsDocumentTemplateEN_USV2 = DocumentTemplate(
-    fields = mapOf(
-        "sms_body" to "{{sender}} sent you {{amount}} USD. It will be available at {{ deposit_expected_at }} UTC. Cancel here: {{ cancelUrl }}",
-        "plaintext_field" to "{{sender}} sent you {{amount}} USD. It will be available at {{ deposit_expected_at }} UTC. Cancel here: {{ cancelUrl }}"
-    ),
-    source = RecipientReceipt::class,
-    targets = setOf(TransactionalSmsDocument::class, ShadowPlaintextDocument::class),
-    locale = EN_US,
-    version = 2
+  fields = mapOf(
+    "sms_body" to "{{sender}} sent you {{amount}} USD. It will be available at {{ deposit_expected_at }} UTC. Cancel here: {{ cancelUrl }}",
+    "plaintext_field" to "{{sender}} sent you {{amount}} USD. It will be available at {{ deposit_expected_at }} UTC. Cancel here: {{ cancelUrl }}"
+  ),
+  source = RecipientReceipt::class,
+  targets = setOf(TransactionalSmsDocument::class, ShadowPlaintextDocument::class),
+  locale = EN_US,
+  version = 2
 )
 
 val plaintextDocumentTemplateEN_US = DocumentTemplate(
-    fields = mapOf(
-        "plaintext_field" to "{{recipient}} sent you {{amount}}. It will be available at {{ deposit_expected_at }}. Cancel here: {{ cancelUrl }}"
-    ),
-    source = SenderReceipt::class,
-    targets = setOf(ShadowPlaintextDocument::class),
-    locale = EN_US
+  fields = mapOf(
+    "plaintext_field" to "{{recipient}} sent you {{amount}}. It will be available at {{ deposit_expected_at }}. Cancel here: {{ cancelUrl }}"
+  ),
+  source = SenderReceipt::class,
+  targets = setOf(ShadowPlaintextDocument::class),
+  locale = EN_US
 )
 
 val investmentPurchaseEncodingDocumentTemplateEN_US = DocumentTemplate(
-    fields = mapOf(
-        "no_annotation_field" to "You purchased {{ shares }} shares of {{ ticker }}.",
-        "default_field" to "You purchased {{ shares }} shares of {{ ticker }}.",
-        "html_field" to "You purchased {{ shares }} shares of {{ ticker }}.",
-        "plaintext_field" to "You purchased {{ shares }} shares of {{ ticker }}."
-    ),
-    source = InvestmentPurchase::class,
-    targets = setOf(EncodingTestDocument::class),
-    locale = EN_US
+  fields = mapOf(
+    "no_annotation_field" to "You purchased {{ shares }} shares of {{ ticker }}.",
+    "default_field" to "You purchased {{ shares }} shares of {{ ticker }}.",
+    "html_field" to "You purchased {{ shares }} shares of {{ ticker }}.",
+    "plaintext_field" to "You purchased {{ shares }} shares of {{ ticker }}.",
+    "url_field" to "{{ url }}",
+  ),
+  source = InvestmentPurchase::class,
+  targets = setOf(EncodingTestDocument::class),
+  locale = EN_US
 )
 
 val investmentPurchaseShadowEncodingDocumentTemplateEN_US = DocumentTemplate(
-    fields = mapOf(
-        "no_annotation_field" to "You purchased {{ shares }} shares of {{ ticker }}.",
-        "default_field" to "You purchased {{ shares }} shares of {{ ticker }}.",
-        "html_field" to "You purchased {{ shares }} shares of {{ ticker }}.",
-        "plaintext_field" to "You purchased {{ shares }} shares of {{ ticker }}.",
-        "non_shadow_field" to "You purchased {{ shares }} shares of {{ ticker }}."
-    ),
-    source = InvestmentPurchase::class,
-    targets = setOf(EncodingTestDocument::class, ShadowEncodingEverythingPlaintextTestDocument::class),
-    locale = EN_US
+  fields = mapOf(
+    "no_annotation_field" to "You purchased {{ shares }} shares of {{ ticker }}.",
+    "default_field" to "You purchased {{ shares }} shares of {{ ticker }}.",
+    "html_field" to "You purchased {{ shares }} shares of {{ ticker }}.",
+    "plaintext_field" to "You purchased {{ shares }} shares of {{ ticker }}.",
+    "url_field" to "{{ url }}",
+    "non_shadow_field" to "You purchased {{ shares }} shares of {{ ticker }}."
+  ),
+  source = InvestmentPurchase::class,
+  targets = setOf(
+    EncodingTestDocument::class, ShadowEncodingEverythingPlaintextTestDocument::class
+  ),
+  locale = EN_US
 )
 
 val recipientReceiptSmsEmailDocumentTemplateEN_US = DocumentTemplate(
-    fields = mapOf(
-        "subject" to "{{sender}} sent you {{amount}}",
-        "headline" to "You received {{amount}}",
-        "short_description" to "You’ve received a payment from {{sender}}! The money will be in your bank account " +
-            "{{deposit_expected_at}}.",
-        "primary_button" to "Cancel this payment",
-        "primary_button_url" to "{{cancelUrl}}",
-        "sms_body" to "{{sender}} sent you {{amount}}"
-    ),
-    source = RecipientReceipt::class,
-    targets = setOf(TransactionalEmailDocument::class, TransactionalSmsDocument::class),
-    locale = EN_US
+  fields = mapOf(
+    "subject" to "{{sender}} sent you {{amount}}",
+    "headline" to "You received {{amount}}",
+    "short_description" to "You’ve received a payment from {{sender}}! The money will be in your bank account " +
+      "{{deposit_expected_at}}.",
+    "primary_button" to "Cancel this payment",
+    "primary_button_url" to "{{cancelUrl}}",
+    "sms_body" to "{{sender}} sent you {{amount}}"
+  ),
+  source = RecipientReceipt::class,
+  targets = setOf(TransactionalEmailDocument::class, TransactionalSmsDocument::class),
+  locale = EN_US
 )
 
 val senderReceiptEmailDocumentTemplateEN_US = DocumentTemplate(
-    fields = mapOf(
-        "subject" to "You sent {{amount}} to {{recipient}}",
-        "headline" to "You sent {{amount}}",
-        "short_description" to "You sent a payment to {{recipient}}! The money will be in their bank account " +
-            "{{deposit_expected_at}}.",
-        "primary_button" to "Cancel this payment",
-        "primary_button_url" to "{{cancelUrl}}"
-    ),
-    source = SenderReceipt::class,
-    targets = setOf(TransactionalEmailDocument::class),
-    locale = EN_US
+  fields = mapOf(
+    "subject" to "You sent {{amount}} to {{recipient}}",
+    "headline" to "You sent {{amount}}",
+    "short_description" to "You sent a payment to {{recipient}}! The money will be in their bank account " +
+      "{{deposit_expected_at}}.",
+    "primary_button" to "Cancel this payment",
+    "primary_button_url" to "{{cancelUrl}}"
+  ),
+  source = SenderReceipt::class,
+  targets = setOf(TransactionalEmailDocument::class),
+  locale = EN_US
 )
 
 val recipientReceiptSmsDocumentTemplateEN_CA = recipientReceiptSmsDocumentTemplateEN_US.copy(
-    fields = recipientReceiptSmsDocumentTemplateEN_US.fields.mapValues { it.value + " Eh?" },
-    locale = EN_CA
+  fields = recipientReceiptSmsDocumentTemplateEN_US.fields.mapValues { it.value + " Eh?" },
+  locale = EN_CA
 )
 
 val recipientReceiptSmsDocumentTemplateEN_GB = recipientReceiptSmsDocumentTemplateEN_US.copy(
-    fields = recipientReceiptSmsDocumentTemplateEN_US.fields.mapValues { it.value + " The Queen approves." },
-    locale = EN_GB
+  fields = recipientReceiptSmsDocumentTemplateEN_US.fields.mapValues { it.value + " The Queen approves." },
+  locale = EN_GB
 )

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -22,6 +22,7 @@ object Dependencies {
   val moshiCore = "com.squareup.moshi:moshi:1.11.0"
   val moshiKotlin = "com.squareup.moshi:moshi-kotlin:1.11.0"
   val mustacheCompiler = "com.github.spullara.mustache.java:compiler:0.9.5"
+  val okHttp = "com.squareup.okhttp3:okhttp:4.10.0-RC1"
   val okio = "com.squareup.okio:okio:2.5.0"
   val shadowJarPlugin = "com.github.jengelman.gradle.plugins:shadow:5.1.0"
   val spotlessPlugin = "com.diffplug.spotless:spotless-plugin-gradle:3.25.0"


### PR DESCRIPTION
DocumentTemplate fields that are URLs do not need to be as wide open as plaintext but can't be as strict as full HTML escaping. Use of OkHttp.HttpUrl for parsing validation and escaping is a good approach.