### PR TITLE
Don't throw exception on invalid URL, escape instead

### DIFF
--- a/barber/src/main/kotlin/app/cash/barber/BarberHttpUrlMustacheFactory.kt
+++ b/barber/src/main/kotlin/app/cash/barber/BarberHttpUrlMustacheFactory.kt
@@ -3,16 +3,27 @@ package app.cash.barber
 import app.cash.barber.models.BarberFieldEncoding.STRING_HTTPURL
 import com.github.mustachejava.DefaultMustacheFactory
 import com.github.mustachejava.MustacheException
+import com.github.mustachejava.util.HtmlEscaper
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import java.io.Writer
 
 /**
  * Mustache Factory that handles [STRING_HTTPURL] fields and doesn't apply the HTML escaping
- *  present in [DefaultMustacheFactory]
+ *  present in [DefaultMustacheFactory] if it's a valid OkHttp.HttpUrl
  */
 class BarberHttpUrlMustacheFactory : DefaultMustacheFactory() {
   override fun encode(value: String?, writer: Writer?) {
-    value?.let { writer?.write(it.toHttpUrl().toString()) }
-      ?: throw MustacheException("Null Writer. Failed to encode value: $value")
+    writer?.let { w ->
+      value?.let { v ->
+        try {
+          // Escape any non-URL valid characters if the value is a valid URL
+          w.write(v.toHttpUrl().toString())
+        } catch (e: IllegalArgumentException) {
+          // Else, assume that this is not a valid URL
+          // Escape the entire string and don't throw an exception
+          HtmlEscaper.escape(v, w)
+        }
+      } ?: throw MustacheException("Null Writer. Failed to encode value: $value")
+    }
   }
 }

--- a/barber/src/main/kotlin/app/cash/barber/BarberPlaintextMustacheFactory.kt
+++ b/barber/src/main/kotlin/app/cash/barber/BarberPlaintextMustacheFactory.kt
@@ -11,7 +11,9 @@ import java.io.Writer
  */
 class BarberPlaintextMustacheFactory : DefaultMustacheFactory() {
   override fun encode(value: String?, writer: Writer?) {
-    value?.let { writer?.write(it) }
-      ?: throw MustacheException("Null Writer. Failed to encode value: $value")
+    value?.let {
+      writer?.write(it)
+        ?: throw MustacheException("Null Writer. Failed to encode value: $value")
+    }
   }
 }

--- a/barber/src/test/kotlin/app/cash/barber/BarberTest.kt
+++ b/barber/src/test/kotlin/app/cash/barber/BarberTest.kt
@@ -276,6 +276,33 @@ class BarberTest {
   }
 
   @Test
+  fun `BarberField URL annotation escapes if field is not valid URL`() {
+    val barber = BarbershopBuilder()
+      .installDocument<EncodingTestDocument>()
+      .installDocumentTemplate<InvestmentPurchase>(
+        investmentPurchaseEncodingDocumentTemplateEN_US
+      )
+      .build()
+
+    val invalidUrlDocumentData = mcDonaldsInvestmentPurchase.copy(
+      url = "<body>not a url</body>"
+    )
+
+    val spec = barber.getBarber<InvestmentPurchase, EncodingTestDocument>()
+      .render(invalidUrlDocumentData, EN_US)
+
+    assertThat(spec).isEqualTo(
+      EncodingTestDocument(
+        no_annotation_field = "You purchased 100 shares of McDonald&#39;s.",
+        default_field = "You purchased 100 shares of McDonald&#39;s.",
+        html_field = "You purchased 100 shares of McDonald&#39;s.",
+        plaintext_field = "You purchased 100 shares of McDonald's.",
+        url_field = "&lt;body&gt;not a url&lt;/body&gt;",
+      )
+    )
+  }
+
+  @Test
   fun `Can install and render multiple versions`() {
     val key = recipientReceiptSmsDocumentTemplateEN_US.fields.keys.first()
     val field = recipientReceiptSmsDocumentTemplateEN_US.fields.values.first()


### PR DESCRIPTION
The BarberField annotation is primarily around encoding choices and not around throwing exceptions on validation, like for example throwing exceptions on invalid URL. 

This change restores that assumption that BarberField annotations change encoding and don't add backwards incompatible exception throwing.