### PR TITLE
Actually pass BarberException message to the super class

### DIFF
--- a/barber/src/main/kotlin/app/cash/barber/BarberException.kt
+++ b/barber/src/main/kotlin/app/cash/barber/BarberException.kt
@@ -26,33 +26,11 @@ package app.cash.barber
 class BarberException(
   val errors: List<String> = listOf(),
   val warnings: List<String> = listOf()
-) : IllegalStateException(toString()) {
+) : IllegalStateException(generateMessage(errors, warnings)) {
+
   override fun toString(): String {
-    val errorText = if (errors.isNotEmpty()) {
-      """
-      |Errors
-      |${errors.sanitize()}
-      """.trimMargin()
-    } else ""
-    val warningText = if (warnings.isNotEmpty()) {
-      """
-      |Warnings
-      |${warnings.sanitize()}
-      """.trimMargin()
-    } else ""
-
-    return if (errors.isEmpty() && warnings.isEmpty()) {
-      "Unknown BarberException"
-    } else if (errors.isNotEmpty() && warnings.isNotEmpty()) {
-      errorText + "\n" + warningText
-    } else {
-      errorText + warningText
-    }
+    return generateMessage(errors, warnings)
   }
-
-  private fun List<String>.sanitize(): String = map { it.replace("$", "::") }
-    .mapIndexed { index, s -> "${index + 1}) $s\n" }
-    .joinToString("\n")
 
   companion object {
     /**
@@ -64,5 +42,35 @@ class BarberException(
         throw BarberException(errors = errors, warnings = warnings)
       }
     }
+
+    private fun generateMessage(errors: List<String>, warnings: List<String>): String {
+      val exceptionSections = listOf(
+          formatExceptionSection("Errors", errors),
+          formatExceptionSection("Warnings", warnings)
+      )
+
+      val exceptionMessage = exceptionSections
+          .filter { it.isNotEmpty() }
+          .joinToString("\n")
+
+      return exceptionMessage.ifEmpty {
+        "Unknown BarberException"
+      }
+    }
+
+    private fun formatExceptionSection(sectionTitle: String, entries: List<String>): String {
+      return if (entries.isEmpty()) {
+        ""
+      } else {
+        """
+        |$sectionTitle
+        |${entries.sanitize()}
+        """.trimMargin()
+      }
+    }
+
+    private fun List<String>.sanitize(): String = map { it.replace("$", "::") }
+        .mapIndexed { index, s -> "${index + 1}) $s\n" }
+        .joinToString("\n")
   }
 }

--- a/barber/src/main/kotlin/app/cash/barber/locale/LocaleResolver.kt
+++ b/barber/src/main/kotlin/app/cash/barber/locale/LocaleResolver.kt
@@ -38,7 +38,7 @@ interface LocaleResolver {
   ): Map<S, T> = when {
     table.isEmpty -> {
       // Usage in Barber prevents the empty case from happening
-      throw BarberException(errors = listOf("Can not resolve entry of an empty Table [templateToken=$templateToken][locale=$locale]."))
+      throw BarberException(errors = listOf("Can not resolve entry of an empty Table [templateToken=$templateToken][locale=${locale.locale}]."))
     }
     table.containsRow(resolve(locale, table.rowKeySet(), templateToken)) -> {
       table.row(resolve(locale, table.rowKeySet(), templateToken))

--- a/barber/src/main/kotlin/app/cash/barber/locale/LocaleResolver.kt
+++ b/barber/src/main/kotlin/app/cash/barber/locale/LocaleResolver.kt
@@ -38,7 +38,7 @@ interface LocaleResolver {
   ): Map<S, T> = when {
     table.isEmpty -> {
       // Usage in Barber prevents the empty case from happening
-      throw BarberException(errors = listOf("Can not resolve entry of an empty Table [templateToken=$templateToken]."))
+      throw BarberException(errors = listOf("Can not resolve entry of an empty Table [templateToken=$templateToken][locale=$locale]."))
     }
     table.containsRow(resolve(locale, table.rowKeySet(), templateToken)) -> {
       table.row(resolve(locale, table.rowKeySet(), templateToken))

--- a/barber/src/test/kotlin/app/cash/barber/locale/LocaleResolverTest.kt
+++ b/barber/src/test/kotlin/app/cash/barber/locale/LocaleResolverTest.kt
@@ -135,7 +135,7 @@ class LocaleResolverTest {
     }
     assertEquals(exception.toString(), """
       |Errors
-      |1) Can not resolve entry of an empty Table [templateToken=alpha].
+      |1) Can not resolve entry of an empty Table [templateToken=alpha][locale=en-US].
       |
     """.trimMargin())
   }


### PR DESCRIPTION
This is a _very_ subtle bug. It was causing the exception to print `app.cash.barber.BarberException$Companion@6c306d83` when logged by our logging framework, instead of its message.

This is because rather than calling the `toString()` method defined below, it was calling the default kotlin `toString()`, since the class hadn't finished initialization yet. This should solve the issue, since the function is now statically defined.