### PR TITLE
Add `toBuilder()` to Barbershop

### DIFF
--- a/barber/src/main/kotlin/app/cash/barber/Barbershop.kt
+++ b/barber/src/main/kotlin/app/cash/barber/Barbershop.kt
@@ -50,6 +50,9 @@ interface Barbershop {
   /** Get any Warnings raised from initial install and validation */
   fun getWarnings(): List<String>
 
+  /** Transform Barbershop back into a builder with all Templates installed */
+  fun toBuilder(): BarbershopBuilder
+
   interface Builder {
     /**
      * Configures this Barbershop so that instances of documentTemplate.templateToken will
@@ -98,10 +101,10 @@ interface Barbershop {
 }
 
 inline fun <reified DD : app.cash.barber.models.DocumentData, reified D : Document> Barbershop.getBarber() = getBarber(
-    DD::class, D::class)
+  DD::class, D::class)
 
 inline fun <reified D : Document> Barbershop.getBarber(templateToken: TemplateToken) = getBarber(
-    templateToken, D::class)
+  templateToken, D::class)
 
 inline fun <reified DD : app.cash.barber.models.DocumentData> Barbershop.getTargetDocuments(version: Long? = null) =
-    getTargetDocuments(documentDataClass = DD::class, version = version)
+  getTargetDocuments(documentDataClass = DD::class, version = version)

--- a/barber/src/main/kotlin/app/cash/barber/Barbershop.kt
+++ b/barber/src/main/kotlin/app/cash/barber/Barbershop.kt
@@ -50,8 +50,8 @@ interface Barbershop {
   /** Get any Warnings raised from initial install and validation */
   fun getWarnings(): List<String>
 
-  /** Transform Barbershop back into a builder with all Templates installed */
-  fun toBuilder(): BarbershopBuilder
+  /** Create a new Builder from the existing Barbershop that includes all existing templates and documents. */
+  fun newBuilder(): BarbershopBuilder
 
   interface Builder {
     /**

--- a/barber/src/main/kotlin/app/cash/barber/RealBarbershop.kt
+++ b/barber/src/main/kotlin/app/cash/barber/RealBarbershop.kt
@@ -95,7 +95,7 @@ internal class RealBarbershop(
 
   override fun getAllBarbers(): Map<BarberKey, Barber<Document>> = barbers
 
-  override fun toBuilder() = BarbershopBuilder().apply {
+  override fun newBuilder() = BarbershopBuilder().apply {
     barbers.keys.forEach {
       installDocument(it.document)
     }

--- a/barber/src/main/kotlin/app/cash/barber/RealBarbershop.kt
+++ b/barber/src/main/kotlin/app/cash/barber/RealBarbershop.kt
@@ -6,6 +6,7 @@ import app.cash.barber.models.TemplateToken
 import app.cash.barber.models.TemplateToken.Companion.getTemplateToken
 import app.cash.barber.version.VersionRange.Companion.supports
 import app.cash.protos.barber.api.DocumentData
+import app.cash.protos.barber.api.DocumentTemplate
 import kotlin.reflect.KClass
 
 internal class RealBarbershop(
@@ -17,7 +18,8 @@ internal class RealBarbershop(
    * may not even be supported by the Barber in the case of a newer version of a Document Template
    * removing the Barber's Document target.
    */
-  private val templateLatestVersions: Map<TemplateToken, Long>
+  private val templateLatestVersions: Map<TemplateToken, Long>,
+  private val documentTemplates: Set<DocumentTemplate>
 ) : Barbershop {
   @Suppress("UNCHECKED_CAST")
   override fun <DD : app.cash.barber.models.DocumentData, D : Document> getBarber(
@@ -57,7 +59,7 @@ internal class RealBarbershop(
       }
       if (problems.isEmpty()) {
         problems.add(
-            "Failed to get Barber<${documentClass.qualifiedName}>(templateToken=$templateToken), unknown error"
+          "Failed to get Barber<${documentClass.qualifiedName}>(templateToken=$templateToken), unknown error"
         )
       }
 
@@ -76,22 +78,31 @@ internal class RealBarbershop(
     version: Long?
   ): Set<KClass<out Document>> = barbers.filter { (barberKey, barber) ->
     barberKey.templateToken == templateToken &&
-        // If version is not explicitly specified, use latestTemplateVersionAcrossAllBarbers
-        barber.supportedVersionRanges.supports(version
-            ?: templateLatestVersions.getValue(barberKey.templateToken)
-        )
+      // If version is not explicitly specified, use latestTemplateVersionAcrossAllBarbers
+      barber.supportedVersionRanges.supports(version
+        ?: templateLatestVersions.getValue(barberKey.templateToken)
+      )
   }.keys.map { it.document }.toSet()
 
   override fun getTargetDocuments(
     documentData: DocumentData,
     version: Long?
   ): Set<KClass<out Document>> =
-      getTargetDocuments(
-        TemplateToken(documentData.template_token!!),
-        version
-      )
+    getTargetDocuments(
+      TemplateToken(documentData.template_token!!),
+      version
+    )
 
   override fun getAllBarbers(): Map<BarberKey, Barber<Document>> = barbers
+
+  override fun toBuilder() = BarbershopBuilder().apply {
+    barbers.keys.forEach {
+      installDocument(it.document)
+    }
+    documentTemplates.forEach {
+      installDocumentTemplate(it)
+    }
+  }
 
   override fun getWarnings(): List<String> = warnings
 }

--- a/barber/src/test/kotlin/app/cash/barber/BarbershopTest.kt
+++ b/barber/src/test/kotlin/app/cash/barber/BarbershopTest.kt
@@ -22,9 +22,9 @@ class BarbershopTest {
   @Test
   fun `getBarber happy path`() {
     val barbershop = BarbershopBuilder()
-        .installDocument<TransactionalSmsDocument>()
-        .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_US)
-        .build()
+      .installDocument<TransactionalSmsDocument>()
+      .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_US)
+      .build()
     val barber = barbershop.getBarber<RecipientReceipt, TransactionalSmsDocument>()
     assertEquals("app.cash.barber.RealBarber", barber::class.qualifiedName)
   }
@@ -32,11 +32,11 @@ class BarbershopTest {
   @Test
   fun `getAllBarbers happy path`() {
     val barbershop = BarbershopBuilder()
-        .installDocument<TransactionalSmsDocument>()
-        .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_US)
-        .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_CA)
-        .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_GB)
-        .build()
+      .installDocument<TransactionalSmsDocument>()
+      .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_US)
+      .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_CA)
+      .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_GB)
+      .build()
     val barbers = barbershop.getAllBarbers()
     assertEquals(1, barbers.size)
     assertThat(barbers.keys).contains(BarberKey(RecipientReceipt::class, TransactionalSmsDocument::class))
@@ -45,17 +45,17 @@ class BarbershopTest {
   @Test
   fun `getBarber fail on non-target Document, with Document installed`() {
     val barber = BarbershopBuilder()
-        .installDocumentTemplate<SenderReceipt>(senderReceiptEmailDocumentTemplateEN_US)
-        .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_US)
-        .installDocument<TransactionalSmsDocument>()
-        .installDocument<TransactionalEmailDocument>()
-        .build()
+      .installDocumentTemplate<SenderReceipt>(senderReceiptEmailDocumentTemplateEN_US)
+      .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_US)
+      .installDocument<TransactionalSmsDocument>()
+      .installDocument<TransactionalEmailDocument>()
+      .build()
 
     val exception = assertFailsWith<BarberException> {
       barber.getBarber<RecipientReceipt, TransactionalEmailDocument>()
     }
     assertEquals(
-        """
+      """
         |Errors
         |1) Failed to get Barber<app.cash.barber.examples.TransactionalEmailDocument>(templateToken=recipientReceipt)
         |Requested Document [class app.cash.barber.examples.TransactionalEmailDocument] is installed
@@ -63,35 +63,35 @@ class BarbershopTest {
         |DocumentTemplate with [templateToken=recipientReceipt] does not have target=[app.cash.barber.examples.TransactionalEmailDocument]
         |
       """.trimMargin(),
-        exception.toString())
+      exception.toString())
   }
 
   @Test
   fun `getBarber fail on non-target Document, with Document not installed`() {
     val barber = BarbershopBuilder()
-        .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_US)
-        .installDocument<TransactionalSmsDocument>()
-        .build()
+      .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_US)
+      .installDocument<TransactionalSmsDocument>()
+      .build()
 
     val exception = assertFailsWith<BarberException> {
       barber.getBarber<RecipientReceipt, TransactionalEmailDocument>()
     }
     assertEquals(
-        """
+      """
         |Errors
         |1) Failed to get Barber<app.cash.barber.examples.TransactionalEmailDocument>(templateToken=recipientReceipt)
         |Document [class app.cash.barber.examples.TransactionalEmailDocument] is not installed in Barbershop
         |
       """.trimMargin(),
-        exception.toString())
+      exception.toString())
   }
 
   @Test
   fun `getTargetDocuments happy path`() {
     val barbershop = BarbershopBuilder()
-        .installDocument<TransactionalSmsDocument>()
-        .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_US)
-        .build()
+      .installDocument<TransactionalSmsDocument>()
+      .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_US)
+      .build()
     val supportedDocuments = barbershop.getTargetDocuments<RecipientReceipt>()
     assertThat(supportedDocuments).containsOnly(TransactionalSmsDocument::class)
   }
@@ -99,23 +99,23 @@ class BarbershopTest {
   @Test
   fun `getTargetDocuments multiple supported documents`() {
     val barbershop = BarbershopBuilder()
-        .installDocument<TransactionalSmsDocument>()
-        .installDocument<TransactionalEmailDocument>()
-        .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsEmailDocumentTemplateEN_US)
-        .build()
+      .installDocument<TransactionalSmsDocument>()
+      .installDocument<TransactionalEmailDocument>()
+      .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsEmailDocumentTemplateEN_US)
+      .build()
     val supportedDocuments = barbershop.getTargetDocuments<RecipientReceipt>()
     assertThat(supportedDocuments).containsOnly(
-        TransactionalSmsDocument::class,
-        TransactionalEmailDocument::class
+      TransactionalSmsDocument::class,
+      TransactionalEmailDocument::class
     )
   }
 
   @Test
   fun `getTargetDocuments no supported documents`() {
     val barbershop = BarbershopBuilder()
-        .installDocument<TransactionalSmsDocument>()
-        .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_US)
-        .build()
+      .installDocument<TransactionalSmsDocument>()
+      .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_US)
+      .build()
     val supportedDocuments = barbershop.getTargetDocuments<SenderReceipt>()
     assertThat(supportedDocuments).isEmpty()
   }
@@ -123,11 +123,11 @@ class BarbershopTest {
   @Test
   fun `getTargetDocuments returns version aware targets`() {
     val barbershop = BarbershopBuilder()
-        .installDocument<TransactionalEmailDocument>()
-        .installDocument<TransactionalSmsDocument>()
-        .installDocumentTemplate<MultiVersionDocumentTargetChangeDocumentData>(multiVersionDocumentTarget_v3_emailSms)
-        .installDocumentTemplate<MultiVersionDocumentTargetChangeDocumentData>(multiVersionDocumentTarget_v4_email)
-        .build()
+      .installDocument<TransactionalEmailDocument>()
+      .installDocument<TransactionalSmsDocument>()
+      .installDocumentTemplate<MultiVersionDocumentTargetChangeDocumentData>(multiVersionDocumentTarget_v3_emailSms)
+      .installDocumentTemplate<MultiVersionDocumentTargetChangeDocumentData>(multiVersionDocumentTarget_v4_email)
+      .build()
 
     val targetDocumentsLatestVersion = barbershop.getTargetDocuments<MultiVersionDocumentTargetChangeDocumentData>()
     assertEquals(setOf(TransactionalEmailDocument::class), targetDocumentsLatestVersion)
@@ -136,5 +136,17 @@ class BarbershopTest {
     assertEquals(setOf(TransactionalEmailDocument::class, TransactionalSmsDocument::class), targetDocumentsVersion1)
     val targetDocumentsVersion2 = barbershop.getTargetDocuments<MultiVersionDocumentTargetChangeDocumentData>(multiVersionDocumentTarget_v4_email.version)
     assertEquals(setOf(TransactionalEmailDocument::class), targetDocumentsVersion2)
+  }
+
+  @Test
+  fun `toBuilder happy path`() {
+    val barbershop = BarbershopBuilder()
+      .installDocument<TransactionalSmsDocument>()
+      .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_US)
+      .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_CA)
+      .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_GB)
+      .build()
+    assertThat(barbershop.toBuilder().build().getAllBarbers().keys)
+      .containsExactlyElementsOf(barbershop.getAllBarbers().keys)
   }
 }

--- a/barber/src/test/kotlin/app/cash/barber/BarbershopTest.kt
+++ b/barber/src/test/kotlin/app/cash/barber/BarbershopTest.kt
@@ -146,7 +146,7 @@ class BarbershopTest {
       .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_CA)
       .installDocumentTemplate<RecipientReceipt>(recipientReceiptSmsDocumentTemplateEN_GB)
       .build()
-    assertThat(barbershop.toBuilder().build().getAllBarbers().keys)
+    assertThat(barbershop.newBuilder().build().getAllBarbers().keys)
       .containsExactlyElementsOf(barbershop.getAllBarbers().keys)
   }
 }


### PR DESCRIPTION
This will allow us to construct a Barbershop with new templates without reloading all existing templates from the database