### PR TITLE
Add backwards compatibility for optional fields in Documents

### DIFF
--- a/barber/src/main/kotlin/app/cash/barber/BarbershopBuilder.kt
+++ b/barber/src/main/kotlin/app/cash/barber/BarbershopBuilder.kt
@@ -48,6 +48,7 @@ class BarbershopBuilder : Barbershop.Builder {
     val document: KClass<out Document>
   )
 
+  // HashBasedTable<BarberSignature, String fieldName, DocumentDb>
   private val installedDocuments =
     HashBasedTable.create<BarberSignature, String, DocumentDb>()
 

--- a/barber/src/main/kotlin/app/cash/barber/models/BarberSignature.kt
+++ b/barber/src/main/kotlin/app/cash/barber/models/BarberSignature.kt
@@ -72,7 +72,9 @@ data class BarberSignature(
 
     fun DocumentData.getBarberSignature() = BarberSignature(asFieldsMap())
 
-    private fun KClass<*>.asFieldsMap(): Map<String, Type> = memberProperties.mapToMaps { kProperty ->
+    private fun KClass<*>.asFieldsMap(includeNullableFields: Boolean = true): Map<String, Type> = memberProperties
+      .filter { includeNullableFields || !it.returnType.isMarkedNullable }
+      .mapToMaps { kProperty ->
       val name = kProperty.name
       // Only recursively define Signature for nested data classes
       val type = kProperty.returnType.classifier as? KClass<*>
@@ -109,5 +111,8 @@ data class BarberSignature(
     )
 
     fun Document.getBarberSignature() = BarberSignature(this::class.asFieldsMap())
+
+    fun KClass<*>.getMinimumRequiredSignatureToSatisfy() =  BarberSignature(asFieldsMap(includeNullableFields = false))
+
   }
 }

--- a/barber/src/test/kotlin/app/cash/barber/examples/TransactionalSmsDocumentWithOptionalMedia.kt
+++ b/barber/src/test/kotlin/app/cash/barber/examples/TransactionalSmsDocumentWithOptionalMedia.kt
@@ -1,0 +1,17 @@
+package app.cash.barber.examples
+
+import app.cash.barber.models.BarberField
+import app.cash.barber.models.BarberFieldEncoding
+import app.cash.barber.models.Document
+
+/**
+ * Used to illustrate compatibility with optional fields,
+ * e.g. if we wanted to add an optional field to the existing [TransactionalSmsDocument]
+ * without causing breaking changes for its existing Documents.
+ */
+data class TransactionalSmsDocumentWithOptionalMedia(
+  val sms_body: String,
+  @BarberField(encoding = BarberFieldEncoding.STRING_PLAINTEXT)
+  // Example addition where we may want to add the ability to send media over MMS
+  val sms_mediaUrl: String? = null,
+) : Document

--- a/barber/src/test/kotlin/app/cash/barber/models/BarberSignatureTest.kt
+++ b/barber/src/test/kotlin/app/cash/barber/models/BarberSignatureTest.kt
@@ -6,12 +6,15 @@ import app.cash.barber.examples.NullableCashBalanceReceipt
 import app.cash.barber.examples.SenderReceipt
 import app.cash.barber.examples.TransactionalEmailDocument
 import app.cash.barber.examples.TransactionalSmsDocument
+import app.cash.barber.examples.TransactionalSmsDocumentWithOptionalMedia
 import app.cash.barber.examples.recipientReceiptSmsDocumentTemplateEN_US
 import app.cash.barber.models.BarberSignature.Companion.getBarberSignature
+import app.cash.barber.models.BarberSignature.Companion.getMinimumRequiredSignatureToSatisfy
 import app.cash.barber.models.BarberSignature.Companion.getNaiveSourceBarberSignature
 import app.cash.protos.barber.api.BarberSignature.Type
 import app.cash.protos.barber.api.DocumentData
 import com.github.mustachejava.DefaultMustacheFactory
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.time.Duration
 import java.time.Instant
@@ -25,10 +28,10 @@ class BarberSignatureTest {
   @Test
   fun `encode happy path`() {
     val fields = mapOf(
-        "name1" to Type.STRING,
-        "name2" to Type.LONG,
-        "name3" to Type.DURATION,
-        "name4" to Type.INSTANT
+      "name1" to Type.STRING,
+      "name2" to Type.LONG,
+      "name3" to Type.DURATION,
+      "name4" to Type.INSTANT
     )
     val actual = BarberSignature(fields)
     assertEquals("name1,1;name2,2;name3,3;name4,4", actual.signature)
@@ -38,10 +41,10 @@ class BarberSignatureTest {
   fun `decode happy path`() {
     val actual = BarberSignature("name1,1;name2,2;name3,3;name4,4")
     val expected = mapOf(
-        "name1" to Type.STRING,
-        "name2" to Type.LONG,
-        "name3" to Type.DURATION,
-        "name4" to Type.INSTANT
+      "name1" to Type.STRING,
+      "name2" to Type.LONG,
+      "name3" to Type.DURATION,
+      "name4" to Type.INSTANT
     )
     assertEquals(expected, actual.fields)
   }
@@ -67,153 +70,180 @@ class BarberSignatureTest {
 
   @Test
   fun `canSatisfy happy path`() {
-    val supersetSource = BarberSignature(mapOf(
+    val supersetSource = BarberSignature(
+      mapOf(
         "name1" to Type.STRING,
         "name2" to Type.LONG,
         "name3" to Type.DURATION,
         "name4" to Type.INSTANT
-    ))
-    val target = BarberSignature(mapOf(
+      )
+    )
+    val target = BarberSignature(
+      mapOf(
         "name1" to Type.STRING,
         "name2" to Type.LONG,
-    ))
+      )
+    )
     val actual = supersetSource.canSatisfy(target)
     assertTrue(actual)
   }
 
   @Test
   fun `canSatisfy failure path`() {
-    val supersetSource = BarberSignature(mapOf(
+    val supersetSource = BarberSignature(
+      mapOf(
         "name1" to Type.STRING,
         "name2" to Type.LONG,
 
-        ))
-    val target = BarberSignature(mapOf(
+        )
+    )
+    val target = BarberSignature(
+      mapOf(
         "name1" to Type.STRING,
         "name2" to Type.LONG,
         "name3" to Type.DURATION,
         "name4" to Type.INSTANT
-    ))
+      )
+    )
     val actual = supersetSource.canSatisfy(target)
     assertFalse(actual)
   }
 
   @Test
   fun `canSatisfyNaively happy path`() {
-    val supersetSource = BarberSignature(mapOf(
+    val supersetSource = BarberSignature(
+      mapOf(
         "name1" to Type.STRING,
         "name2" to Type.LONG,
         "name3" to Type.DURATION,
         "name4" to Type.INSTANT
-    ))
-    val target = BarberSignature(mapOf(
+      )
+    )
+    val target = BarberSignature(
+      mapOf(
         "name1" to Type.STRING,
         "name2" to Type.STRING,
-    ))
+      )
+    )
     assertTrue(supersetSource.canSatisfyNaively(target))
   }
 
   @Test
   fun `canSatisfyNaively failure path`() {
-    val supersetSource = BarberSignature(mapOf(
+    val supersetSource = BarberSignature(
+      mapOf(
         "name1" to Type.STRING,
         "name2" to Type.STRING,
 
-        ))
-    val target = BarberSignature(mapOf(
+        )
+    )
+    val target = BarberSignature(
+      mapOf(
         "name1" to Type.STRING,
         "name2" to Type.LONG,
         "name3" to Type.DURATION,
         "name4" to Type.INSTANT
-    ))
+      )
+    )
     assertFalse(supersetSource.canSatisfyNaively(target))
   }
 
   @Test
   fun `signature from Proto DocumentData`() {
     val actual = DocumentData(
-        template_token = "T_123",
-        fields = listOf(
-            DocumentData.Field(
-                key = "recipient",
-                value_string = "recipient"
-            ),
-            DocumentData.Field(
-                key = "score",
-                value_long = 420
-            ),
-            DocumentData.Field(
-                key = "waiting_time",
-                value_duration = Duration.ZERO
-            ),
-            DocumentData.Field(
-                key = "expected_at",
-                value_instant = Instant.EPOCH
-            )
+      template_token = "T_123",
+      fields = listOf(
+        DocumentData.Field(
+          key = "recipient",
+          value_string = "recipient"
+        ),
+        DocumentData.Field(
+          key = "score",
+          value_long = 420
+        ),
+        DocumentData.Field(
+          key = "waiting_time",
+          value_duration = Duration.ZERO
+        ),
+        DocumentData.Field(
+          key = "expected_at",
+          value_instant = Instant.EPOCH
         )
+      )
     ).getBarberSignature()
-    val expected = BarberSignature(mapOf(
+    val expected = BarberSignature(
+      mapOf(
         "recipient" to Type.STRING,
         "score" to Type.LONG,
         "waiting_time" to Type.DURATION,
         "expected_at" to Type.INSTANT,
-    ))
+      )
+    )
     assertEquals(expected, actual)
   }
 
   @Test
   fun `signature from Kotlin DocumentData class`() {
     val actual = SenderReceipt::class.getBarberSignature()
-    val expected = BarberSignature(mapOf(
+    val expected = BarberSignature(
+      mapOf(
         "recipient" to Type.STRING,
         "amount" to Type.STRING,
         "cancelUrl" to Type.STRING,
         "deposit_expected_at" to Type.INSTANT,
-    ))
+      )
+    )
     assertEquals(expected, actual)
   }
 
   @Test
   fun `signature from Kotlin DocumentData`() {
     val actual = SenderReceipt(
-        recipient = "test",
-        amount = "test",
-        cancelUrl = "test",
-        deposit_expected_at = Instant.EPOCH
+      recipient = "test",
+      amount = "test",
+      cancelUrl = "test",
+      deposit_expected_at = Instant.EPOCH
     ).getBarberSignature()
-    val expected = BarberSignature(mapOf(
+    val expected = BarberSignature(
+      mapOf(
         "recipient" to Type.STRING,
         "amount" to Type.STRING,
         "cancelUrl" to Type.STRING,
         "deposit_expected_at" to Type.INSTANT,
-    ))
+      )
+    )
     assertEquals(expected, actual)
   }
 
   @Test
   fun `signature from Document class`() {
     val actual = TransactionalSmsDocument::class.getBarberSignature()
-    val expected = BarberSignature(mapOf(
+    val expected = BarberSignature(
+      mapOf(
         "sms_body" to Type.STRING,
-    ))
+      )
+    )
     assertEquals(expected, actual)
   }
 
   @Test
   fun `signature from Document`() {
     val actual = TransactionalSmsDocument(
-        sms_body = "test"
+      sms_body = "test"
     ).getBarberSignature()
-    val expected = BarberSignature(mapOf(
+    val expected = BarberSignature(
+      mapOf(
         "sms_body" to Type.STRING,
-    ))
+      )
+    )
     assertEquals(expected, actual)
   }
 
   @Test
   fun `signature from Document class with nullable fields`() {
     val actual = TransactionalEmailDocument::class.getBarberSignature()
-    val expected = BarberSignature(mapOf(
+    val expected = BarberSignature(
+      mapOf(
         "subject" to Type.STRING,
         "headline" to Type.STRING,
         "short_description" to Type.STRING,
@@ -221,138 +251,157 @@ class BarberSignatureTest {
         "primary_button_url" to Type.STRING,
         "secondary_button" to Type.STRING,
         "secondary_button_url" to Type.STRING,
-    ))
+      )
+    )
     assertEquals(expected, actual)
   }
 
   @Test
   fun `signature for nested Kotlin DocumentData data class`() {
     val nestedLoginCode = NestedLoginCode(
-        code = "123-456",
-        button = NestedLoginCode.EmailButton(
-            color = "#B3B3B3",
-            text = "Login",
-            link = "https://cash.app/login",
-            size = "regular"
-        )
+      code = "123-456",
+      button = NestedLoginCode.EmailButton(
+        color = "#B3B3B3",
+        text = "Login",
+        link = "https://cash.app/login",
+        size = "regular"
+      )
     )
     val actual = nestedLoginCode.getBarberSignature()
-    val expected = BarberSignature(mapOf(
+    val expected = BarberSignature(
+      mapOf(
         "code" to Type.STRING,
         "button.color" to Type.STRING,
         "button.text" to Type.STRING,
         "button.link" to Type.STRING,
         "button.size" to Type.STRING,
-    ))
+      )
+    )
     assertEquals(expected, actual)
   }
 
   @Test
   fun `signature from nested Proto DocumentData`() {
     val actual = DocumentData(
-        template_token = "T_123",
-        fields = listOf(
-            DocumentData.Field(
-                key = "recipient",
-                value_string = "recipient"
-            ),
-            DocumentData.Field(
-                key = "score.metric1",
-                value_long = 420
-            ),
-            DocumentData.Field(
-                key = "score.metric2",
-                value_long = 69
-            ),
-        )
+      template_token = "T_123",
+      fields = listOf(
+        DocumentData.Field(
+          key = "recipient",
+          value_string = "recipient"
+        ),
+        DocumentData.Field(
+          key = "score.metric1",
+          value_long = 420
+        ),
+        DocumentData.Field(
+          key = "score.metric2",
+          value_long = 69
+        ),
+      )
     ).getBarberSignature()
-    val expected = BarberSignature(mapOf(
+    val expected = BarberSignature(
+      mapOf(
         "recipient" to Type.STRING,
         "score.metric1" to Type.LONG,
         "score.metric2" to Type.LONG,
-    ))
+      )
+    )
     assertEquals(expected, actual)
   }
 
   @Test
   fun `signature for nested Kotlin DocumentData data class converted to Proto`() {
     val nestedLoginCode = NestedLoginCode(
-        code = "123-456",
-        button = NestedLoginCode.EmailButton(
-            color = "#B3B3B3",
-            text = "Login",
-            link = "https://cash.app/login",
-            size = "regular"
-        )
+      code = "123-456",
+      button = NestedLoginCode.EmailButton(
+        color = "#B3B3B3",
+        text = "Login",
+        link = "https://cash.app/login",
+        size = "regular"
+      )
     )
     val nestedProto = nestedLoginCode.toProto()
     val actual = nestedProto.getBarberSignature()
-    val expected = BarberSignature(mapOf(
+    val expected = BarberSignature(
+      mapOf(
         "code" to Type.STRING,
         "button.color" to Type.STRING,
         "button.text" to Type.STRING,
         "button.link" to Type.STRING,
         "button.size" to Type.STRING,
-    ))
+      )
+    )
     assertEquals(expected, actual)
   }
 
   @Test
   fun `implicit source signature for DocumentTemplate proto`() {
     val actual = recipientReceiptSmsDocumentTemplateEN_US
-        .toProto()
-        .getNaiveSourceBarberSignature(mustacheFactory)
-    val expected = BarberSignature(mapOf(
+      .toProto()
+      .getNaiveSourceBarberSignature(mustacheFactory)
+    val expected = BarberSignature(
+      mapOf(
         "sender" to Type.STRING,
         "amount" to Type.STRING,
         "cancelUrl" to Type.STRING,
         "deposit_expected_at" to Type.STRING,
-    ))
+      )
+    )
     assertEquals(expected, actual)
   }
 
   @Test
   fun `Use value_null_type or default to String for null DocumentData Fields when Signature calculation is ambiguous`() {
     val actual = DocumentData(
-        template_token = "T_123",
-        fields = listOf(
-            DocumentData.Field(
-                key = "alpha",
-                value_string = "non null"
-            ),
-            DocumentData.Field(
-                key = "bravo",
-                value_null_type = Type.DURATION
-            ),
-            DocumentData.Field(
-                key = "charlie"
-            )
+      template_token = "T_123",
+      fields = listOf(
+        DocumentData.Field(
+          key = "alpha",
+          value_string = "non null"
+        ),
+        DocumentData.Field(
+          key = "bravo",
+          value_null_type = Type.DURATION
+        ),
+        DocumentData.Field(
+          key = "charlie"
         )
+      )
     ).getBarberSignature()
-    val expected = BarberSignature(mapOf(
+    val expected = BarberSignature(
+      mapOf(
         "alpha" to Type.STRING,
         "bravo" to Type.DURATION,
         "charlie" to Type.STRING,
-    ))
+      )
+    )
     assertEquals(expected, actual)
   }
 
   @Test
   fun `Kotlin DocumentData signature fills in value_null_type for null value`() {
     val documentData = NullableCashBalanceReceipt(
-        amount = 50
+      amount = 50
     )
 
     val documentDataProto = documentData.toProto()
     assertEquals(Type.LONG, documentDataProto.fields.last().value_null_type)
-    
+
     val kotlinSignature = documentData.getBarberSignature()
     val protoSignature = documentDataProto.getBarberSignature()
-    val expected = BarberSignature(mapOf(
+    val expected = BarberSignature(
+      mapOf(
         "amount" to Type.LONG,
         "cashBalance" to Type.LONG,
-    ))
+      )
+    )
     assertEquals(expected, kotlinSignature)
     assertEquals(expected, protoSignature)
+  }
+
+  @Test
+  fun `getMinimumRequiredSignatureToSatisfy does not include optional fields`() {
+    assertThat(TransactionalSmsDocumentWithOptionalMedia::class.getMinimumRequiredSignatureToSatisfy())
+      .isEqualTo(BarberSignature(mapOf("sms_body" to Type.STRING)))
   }
 }


### PR DESCRIPTION
When a `Document` field is optional, we no longer validate that it's necessary in the `fields` or `target_signature` of a `DocumentTemplate` to be installed 

Also changing the `Installed DocumentTemplate has additional fields that are not used in any target Document` error to a warning, so that a code rollback is still possible after an optional field is added to a `Document` 