### PR TITLE
Migrate to Sonatype Central Portal

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -49,9 +49,10 @@ jobs:
     needs: [jvm]
     runs-on: [ubuntu-latest]
     env:
-      ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
-      ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
-      ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.ARTIFACT_SIGNING_PRIVATE_KEY }}
+      ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_CENTRAL_USERNAME }}
+      ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_CENTRAL_PASSWORD }}
+      ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_SECRET_KEY }}
+      ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_SECRET_PASSPHRASE }}
 
     steps:
       - name: Checkout

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,7 +27,7 @@ allprojects {
 
   plugins.withId("com.vanniktech.maven.publish.base") {
     configure<MavenPublishBaseExtension> {
-      publishToMavenCentral(SonatypeHost.DEFAULT, automaticRelease = true)
+      publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL, automaticRelease = true)
       signAllPublications()
       pom {
         description.set("A type safe Kotlin JVM library for building up localized, fillable, themed documents using Mustache templating.")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,7 +20,7 @@ kotlinScriptRuntime = { module = "org.jetbrains.kotlin:kotlin-script-runtime", v
 kotlinStdLibJdk8 = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version = "1.8.21" }
 kotlinTest = { module = "org.jetbrains.kotlin:kotlin-test", version = "1.8.21" }
 loggingApi = { module = "io.github.microutils:kotlin-logging", version = "1.7.9" }
-mavenPublishGradlePlugin = { module = "com.vanniktech:gradle-maven-publish-plugin", version = "0.25.2" }
+mavenPublishGradlePlugin = { module = "com.vanniktech:gradle-maven-publish-plugin", version = "0.31.0" }
 moshiCore = { module = "com.squareup.moshi:moshi", version = "1.15.0" }
 moshiKotlin = { module = "com.squareup.moshi:moshi-kotlin", version = "1.15.0" }
 mustacheCompiler = { module = "com.github.spullara.mustache.java:compiler", version = "0.9.5" }


### PR DESCRIPTION
# DO NOT MERGE!!!

See (internally) http://go/central-portal-migration-app-cash for context.